### PR TITLE
feat(workspace): promote source-provided agent skills

### DIFF
--- a/packages/workspace/src/sources/materialization.ts
+++ b/packages/workspace/src/sources/materialization.ts
@@ -159,9 +159,9 @@ function sourceSkillPromotion(path: string): { destination: string, root: typeof
 
 function isPromotedSourceSkillFile(value: unknown): value is PromotedSourceSkillFile {
   return hasRuntimeType(value, "object") && value !== null
-    && readStringMeta(value as Record<string, unknown>, "digest") !== undefined
-    && readStringMeta(value as Record<string, unknown>, "source") !== undefined
-    && readStringMeta(value as Record<string, unknown>, "sourcePath") !== undefined
+    && hasRuntimeType(Reflect.get(value, "digest"), "string")
+    && hasRuntimeType(Reflect.get(value, "source"), "string")
+    && hasRuntimeType(Reflect.get(value, "sourcePath"), "string")
 }
 
 async function reconcilePromotedSourceSkills(

--- a/packages/workspace/src/sources/materialization.ts
+++ b/packages/workspace/src/sources/materialization.ts
@@ -60,7 +60,14 @@ interface MaterializedStartupSource {
   mountPath: string
 }
 
+interface PromotedSourceSkillFile {
+  digest: string
+  source: string
+  sourcePath: string
+}
+
 const startupSourcesMetaKey = "workspace:startup-sources"
+const promotedSourceSkillsMetaKey = "workspace:promoted-source-skills"
 const startupReconciliationByStore = new WeakMap<WorkspaceStore, Promise<void>>()
 const activeStartupSourcesByStore = new WeakMap<WorkspaceStore, Set<ResolvedWorkspaceSource>>()
 
@@ -136,6 +143,112 @@ export async function sourceSnapshotOwnsAnyPath(store: WorkspaceStore, sourceKey
 
 async function writeSourceSnapshotMetadata(store: WorkspaceStore, metadata: SourceSnapshotMetadata) {
   await store.setMeta?.(sourceSnapshotMetaKey(metadata.source), metadata)
+}
+
+const sourceSkillRoots = [".agents", ".claude", ".codex"] as const
+
+function sourceSkillPromotion(path: string): { destination: string, root: typeof sourceSkillRoots[number], skill: string } | undefined {
+  const root = sourceSkillRoots.find(candidate => path.includes(`/${candidate}/skills/`))
+  if (!root) return
+  const marker = `/${root}/skills/`
+  const relative = path.slice(path.indexOf(marker) + marker.length)
+  const [skill, ...rest] = relative.split("/")
+  if (!skill || !/^[a-z0-9][a-z0-9-]*$/.test(skill) || !rest.length) return
+  return { destination: `.agents/skills/${skill}/${rest.join("/")}`, root, skill }
+}
+
+function isPromotedSourceSkillFile(value: unknown): value is PromotedSourceSkillFile {
+  return hasRuntimeType(value, "object") && value !== null
+    && readStringMeta(value as Record<string, unknown>, "digest") !== undefined
+    && readStringMeta(value as Record<string, unknown>, "source") !== undefined
+    && readStringMeta(value as Record<string, unknown>, "sourcePath") !== undefined
+}
+
+async function reconcilePromotedSourceSkills(
+  store: WorkspaceStore,
+  sources: readonly ResolvedWorkspaceSource[],
+  control: MaterializationControl,
+) {
+  if (!store.getMeta || !store.setMeta) return
+  const previousValue = await store.getMeta(promotedSourceSkillsMetaKey)
+  const previous = hasRuntimeType(previousValue, "object") && previousValue !== null
+    ? Object.fromEntries(Object.entries(previousValue).filter((entry): entry is [string, PromotedSourceSkillFile] => isPromotedSourceSkillFile(entry[1])))
+    : {}
+  const selectedSkills = new Map<string, { paths: string[], source: string }>()
+  const sortedSources = [...sources].sort((left, right) => left.key.localeCompare(right.key))
+  for (const source of sortedSources) {
+    const snapshot = await readSourceSnapshotMetadata(store, source.key)
+    if (snapshot?.status !== "ready") continue
+    const pathsBySkill = new Map<string, Map<typeof sourceSkillRoots[number], string[]>>()
+    for (const sourcePath of Object.keys(snapshot.items || {}).sort()) {
+      const promotion = sourceSkillPromotion(sourcePath)
+      if (!promotion) continue
+      const pathsByRoot = pathsBySkill.get(promotion.skill) || new Map()
+      const paths = pathsByRoot.get(promotion.root) || []
+      paths.push(sourcePath)
+      pathsByRoot.set(promotion.root, paths)
+      pathsBySkill.set(promotion.skill, pathsByRoot)
+    }
+    for (const [skill, pathsByRoot] of pathsBySkill) {
+      if (selectedSkills.has(skill)) continue
+      const paths = sourceSkillRoots.map(root => pathsByRoot.get(root)).find(candidate => candidate?.some(path => path.endsWith("/SKILL.md")))
+      if (paths) selectedSkills.set(skill, { paths, source: source.key })
+    }
+  }
+
+  const candidates = new Map<string, { source: string, sourcePath: string }>()
+  const retainedSkills = new Set<string>()
+  for (const [skill, selected] of selectedSkills) {
+    const rootSkillPath = `.agents/skills/${skill}/SKILL.md`
+    const existingRootSkill = await store.readFile(rootSkillPath)
+    const previousRootSkill = previous[rootSkillPath]
+    const ownsRootSkill = Boolean(previousRootSkill && existingRootSkill && await sha256(existingRootSkill.content) === previousRootSkill.digest)
+    if (existingRootSkill && !ownsRootSkill) {
+      retainedSkills.add(skill)
+      continue
+    }
+    for (const sourcePath of selected.paths) {
+      const promotion = sourceSkillPromotion(sourcePath)
+      if (!promotion || sourcePath === promotion.destination) continue
+      candidates.set(promotion.destination, { source: selected.source, sourcePath })
+    }
+  }
+  for (const [path, prior] of Object.entries(previous)) {
+    if (!path.endsWith("/SKILL.md")) continue
+    const promotion = sourceSkillPromotion(`source/${path}`)
+    if (!promotion) continue
+    const existing = await store.readFile(path)
+    if (existing && await sha256(existing.content) !== prior.digest) retainedSkills.add(promotion.skill)
+  }
+
+  const next: Record<string, PromotedSourceSkillFile> = Object.fromEntries(Object.entries(previous).filter(([path]) => {
+    const promotion = sourceSkillPromotion(`source/${path}`)
+    return promotion && retainedSkills.has(promotion.skill)
+  }))
+  for (const [destination, candidate] of candidates) {
+    const sourceFile = await store.readFile(candidate.sourcePath)
+    if (!sourceFile) continue
+    const existing = await store.readFile(destination)
+    const prior = previous[destination]
+    const ownsExisting = Boolean(prior && existing && await sha256(existing.content) === prior.digest)
+    if (existing && !ownsExisting) continue
+    const metadata = {
+      ...sourceFile.metadata,
+      promotedSourceSkill: { source: candidate.source, sourcePath: candidate.sourcePath },
+    }
+    await control.mutate(async () => {
+      await store.mkdir(posix.dirname(destination), { recursive: true })
+      await store.writeFile(destination, { ...sourceFile, path: destination, metadata })
+    })
+    next[destination] = { ...candidate, digest: await sha256(sourceFile.content) }
+  }
+  for (const [destination, prior] of Object.entries(previous)) {
+    if (next[destination]) continue
+    const existing = await store.readFile(destination)
+    if (existing && await sha256(existing.content) === prior.digest) await control.mutate(() => store.rm(destination, { force: true }))
+    else if (existing) next[destination] = prior
+  }
+  await control.checkpoint(async () => await store.setMeta?.(promotedSourceSkillsMetaKey, next))
 }
 
 function materializedItemMeta(
@@ -910,6 +1023,10 @@ async function materializeWorkspaceSourcesInternal(
       })
       if (options.abortSignal?.aborted) throw error
     }
+  }
+
+  if (rootMaterialization && control.isCurrent()) {
+    await reconcilePromotedSourceSkills(store, configuredSources, control)
   }
 
   return {

--- a/packages/workspace/test/lazy-sources.test.ts
+++ b/packages/workspace/test/lazy-sources.test.ts
@@ -34,6 +34,97 @@ afterEach(async () => {
 })
 
 describe("lazy sources", () => {
+  it("promotes complete source skills while preserving their mounted files", async () => {
+    const store = createMemoryWorkspaceStore()
+    const view = createWorkspaceSourceView({
+      name: "source-skills",
+      sources: {
+        portal: custom({
+          materialize: "startup",
+          mount: "portal",
+          files: [
+            { path: ".agents/skills/perf-investigate/SKILL.md", content: "# Performance\n" },
+            { path: ".agents/skills/perf-investigate/checks.md", content: "# Checks\n" },
+            { path: ".agents/skills/k8s-environments/SKILL.md", content: "# Kubernetes\n" },
+            { path: ".claude/skills/legacy-review/SKILL.md", content: "# Legacy review\n" },
+            { path: ".claude/skills/legacy-review/reference.md", content: "# Legacy reference\n" },
+            { path: ".codex/skills/codex-review/SKILL.md", content: "# Codex review\n" },
+            { path: ".agents/skills/root-priority/SKILL.md", content: "# Canonical\n" },
+            { path: ".agents/skills/root-priority/canonical.md", content: "# Canonical companion\n" },
+            { path: ".claude/skills/root-priority/SKILL.md", content: "# Claude fallback\n" },
+            { path: ".claude/skills/root-priority/legacy.md", content: "# Legacy companion\n" },
+          ],
+        }),
+        zeta: custom({
+          materialize: "startup",
+          mount: "zeta",
+          files: [
+            { path: ".agents/skills/k8s-environments/SKILL.md", content: "# Conflicting Kubernetes\n" },
+            { path: ".agents/skills/k8s-environments/zeta.md", content: "# Zeta only\n" },
+          ],
+        }),
+      },
+    }, store)
+
+    await view.materializeSources()
+
+    await expect(view.readFile(".agents/skills/perf-investigate/SKILL.md")).resolves.toBe("# Performance\n")
+    await expect(view.readFile(".agents/skills/perf-investigate/checks.md")).resolves.toBe("# Checks\n")
+    await expect(view.readFile(".agents/skills/k8s-environments/SKILL.md")).resolves.toBe("# Kubernetes\n")
+    await expect(view.readFile(".agents/skills/legacy-review/SKILL.md")).resolves.toBe("# Legacy review\n")
+    await expect(view.readFile(".agents/skills/legacy-review/reference.md")).resolves.toBe("# Legacy reference\n")
+    await expect(view.readFile(".agents/skills/codex-review/SKILL.md")).resolves.toBe("# Codex review\n")
+    await expect(view.readFile(".agents/skills/root-priority/SKILL.md")).resolves.toBe("# Canonical\n")
+    await expect(view.readFile(".agents/skills/root-priority/canonical.md")).resolves.toBe("# Canonical companion\n")
+    await expect(view.exists(".agents/skills/root-priority/legacy.md")).resolves.toBe(false)
+    await expect(view.exists(".agents/skills/k8s-environments/zeta.md")).resolves.toBe(false)
+    await expect(view.readFile("portal/.agents/skills/perf-investigate/SKILL.md")).resolves.toBe("# Performance\n")
+    await expect(view.readFile("portal/.claude/skills/legacy-review/SKILL.md")).resolves.toBe("# Legacy review\n")
+    await expect(view.readFile("portal/.codex/skills/codex-review/SKILL.md")).resolves.toBe("# Codex review\n")
+    await expect(view.readFile("zeta/.agents/skills/k8s-environments/SKILL.md")).resolves.toBe("# Conflicting Kubernetes\n")
+    await expect(store.readFile(".agents/skills/perf-investigate/SKILL.md")).resolves.toMatchObject({
+      metadata: { promotedSourceSkill: { source: "portal", sourcePath: "portal/.agents/skills/perf-investigate/SKILL.md" } },
+    })
+  })
+
+  it("keeps explicit and edited root skills during source refresh", async () => {
+    const store = createMemoryWorkspaceStore()
+    let files = [
+      { path: ".agents/skills/shared/SKILL.md", content: "# Source shared\n" },
+      { path: ".agents/skills/shared/source.md", content: "# Source companion\n" },
+      { path: ".agents/skills/source-only/SKILL.md", content: "# Source only\n" },
+      { path: ".agents/skills/source-only/reference.md", content: "# Reference\n" },
+    ]
+    await store.mkdir(".agents/skills/shared", { recursive: true })
+    await store.writeFile(".agents/skills/shared/SKILL.md", { path: ".agents/skills/shared/SKILL.md", content: "# Explicit\n" })
+    const definition = {
+      name: "source-skill-collisions",
+      sources: {
+        portal: custom({
+          materialize: "startup" as const,
+          mount: "portal",
+          sync: { stale: "remove" as const },
+          async getKeys() { return files.map(file => file.path) },
+          async getItem(key: string) { return { key, ...files.find(file => file.path === key)! } },
+        }),
+      },
+    }
+    const view = createWorkspaceSourceView(definition, store)
+    await view.materializeSources()
+    await expect(view.readFile(".agents/skills/shared/SKILL.md")).resolves.toBe("# Explicit\n")
+    await expect(view.exists(".agents/skills/shared/source.md")).resolves.toBe(false)
+    await expect(view.readFile(".agents/skills/source-only/SKILL.md")).resolves.toBe("# Source only\n")
+    await expect(view.readFile(".agents/skills/source-only/reference.md")).resolves.toBe("# Reference\n")
+
+    await store.writeFile(".agents/skills/source-only/SKILL.md", { path: ".agents/skills/source-only/SKILL.md", content: "# Locally edited\n" })
+    files = []
+    await view.materializeSources()
+
+    await expect(view.readFile(".agents/skills/shared/SKILL.md")).resolves.toBe("# Explicit\n")
+    await expect(view.readFile(".agents/skills/source-only/SKILL.md")).resolves.toBe("# Locally edited\n")
+    await expect(view.readFile(".agents/skills/source-only/reference.md")).resolves.toBe("# Reference\n")
+  })
+
   it("refreshes nested startup files before the first directory listing", async () => {
     const store = createMemoryWorkspaceStore()
     let keys = ["stale.md"]


### PR DESCRIPTION
Mounted sources can contain project skills, but agents only discover skills from the Workspace root. This promotes complete `.agents/skills`, `.claude/skills`, and `.codex/skills` directories into root `.agents/skills` during materialization while preserving the mounted originals.

Promotion keeps deterministic whole-skill ownership, prefers canonical `.agents` skills within a source, preserves explicit or edited root skills, and records source provenance for refresh and cleanup.

Validation: `pnpm exec vp test test/lazy-sources.test.ts -t "source skills|root skills"` (2 passed, 179 skipped; no type errors).
