### PR TITLE
Validate typed channel trigger input

### DIFF
--- a/docs/content/docs/agents/triggers.md
+++ b/docs/content/docs/agents/triggers.md
@@ -108,13 +108,20 @@ Use `defineChannel()` when an application-owned Channel Kind prepares its own ev
 
 ```ts [server/agents/support.ts]
 import { defineAgent } from 'vite-hub/agent'
-import { defineChannel } from 'vite-hub/agent/channels'
+import { defineChannel, defineChannelTrigger } from 'vite-hub/agent/channels'
+import * as v from 'valibot'
+
+const ticketOpened = v.object({
+  ticketId: v.string(),
+  summary: v.pipe(v.string(), v.trim(), v.minLength(1)),
+})
 
 const ticketing = defineChannel('ticketing', {
   messages: false,
   triggers: {
-    'ticket.opened': {
-      invoke(context, event: { ticketId: string, summary: string }) {
+    'ticket.opened': defineChannelTrigger({
+      input: ticketOpened,
+      invoke(context, event) {
         return {
           input: {
             prompt: `Triage ticket ${event.ticketId}: ${event.summary}`,
@@ -126,7 +133,7 @@ const ticketing = defineChannel('ticketing', {
           },
         }
       },
-    },
+    }),
   },
 })
 
@@ -136,7 +143,9 @@ export default defineAgent({
 })
 ```
 
-The Trigger translates the event and attaches trusted context. Keep model selection, tools, and execution behavior in the Agent Definition.
+`defineChannelTrigger()` infers `event` from any [Standard Schema](https://standardschema.dev/) implementation. ViteHub validates and applies schema transforms before `invoke()`. Webhook authentication runs first, and invalid webhook input receives a generic `400 invalid_payload` response without exposing schema details.
+
+The Trigger translates the validated event and attaches trusted context. Keep model selection, tools, and execution behavior in the Agent Definition.
 
 ## Choose how to call the Agent
 

--- a/packages/agent/src/channels.ts
+++ b/packages/agent/src/channels.ts
@@ -57,6 +57,7 @@ import type { TelegramAdapterConfig } from "@chat-adapter/telegram"
 import { resolveRuntimeValue } from "@vite-hub/runtime"
 import type { Adapter, FileUpload } from "chat"
 import { agentDiagnostics } from "./agent-diagnostics.ts"
+import type { WorkspaceName } from "@vite-hub/workspace"
 
 export const messageChannelTitleSupportContextKey = "channel.delivery.supportsTitle"
 const customTitleEffectChannels = new WeakSet<object>()

--- a/packages/agent/src/channels.ts
+++ b/packages/agent/src/channels.ts
@@ -2762,6 +2762,14 @@ export function defineChannel<TRuntimeConfig extends AgentRuntimeConfig = AgentR
   return channel
 }
 
+export function defineChannelTrigger<
+  TInput,
+  TRuntimeConfig extends AgentRuntimeConfig = AgentRuntimeConfig,
+  CALL_OPTIONS = unknown,
+>(definition: AgentTriggerDefinition<TRuntimeConfig, WorkspaceName, TInput, CALL_OPTIONS, AgentChannelTriggerContext<TRuntimeConfig>>): typeof definition {
+  return definition
+}
+
 export function discord<TRuntimeConfig extends AgentRuntimeConfig = AgentRuntimeConfig>(
   options: DiscordChannelOptions<TRuntimeConfig> = {},
 ): AgentChannelDefinition<TRuntimeConfig> {

--- a/packages/agent/src/trigger-runtime.ts
+++ b/packages/agent/src/trigger-runtime.ts
@@ -440,16 +440,17 @@ export async function resolveAgentTriggerInvocation<
   }
   let validatedInput = input
   if (trigger.input && "~standard" in Object(trigger.input)) {
-    try {
-      validatedInput = await parseStandardSchema(trigger.input, input, `Agent trigger "${trigger.id}" input`)
-    } catch (error) {
-      if (trigger.webhooks?.length && context.request) {
+    if (trigger.webhooks?.length && context.request) {
+      const result = await trigger.input["~standard"].validate(input)
+      if (result.issues?.length || !("value" in result)) {
         return {
           response: Response.json({ accepted: false, reason: "invalid_payload" }, { status: 400 }),
           trigger,
         }
       }
-      throw error
+      validatedInput = result.value
+    } else {
+      validatedInput = await parseStandardSchema(trigger.input, input, `Agent trigger "${trigger.id}" input`)
     }
   }
   return resolveAgentTriggerInvocationResult(await trigger.invoke(validatedInput), trigger)

--- a/packages/agent/src/trigger-runtime.ts
+++ b/packages/agent/src/trigger-runtime.ts
@@ -441,12 +441,12 @@ export async function resolveAgentTriggerInvocation<
   let validatedInput = input
   if (trigger.input && "~standard" in Object(trigger.input)) {
     try {
-      validatedInput = await parseStandardSchema(trigger.input, input, `Agent trigger "${trigger.id}" input`) as TInput
+      validatedInput = await parseStandardSchema(trigger.input, input, `Agent trigger "${trigger.id}" input`)
     } catch (error) {
       if (trigger.webhooks?.length && context.request) {
         return {
           response: Response.json({ accepted: false, reason: "invalid_payload" }, { status: 400 }),
-          trigger: trigger as never,
+          trigger,
         }
       }
       throw error

--- a/packages/agent/src/trigger-runtime.ts
+++ b/packages/agent/src/trigger-runtime.ts
@@ -4,6 +4,7 @@ import {
   normalizeCapabilities,
 } from "./capability-runtime.ts"
 import { AgentHttpError } from "./http-error.ts"
+import { hasRuntimeType, isRuntimeRecord } from "./internal/runtime-type.ts"
 
 import type {
   AgentCallbackContext,
@@ -29,8 +30,15 @@ import type {
 } from "./types.ts"
 import { parseStandardSchema } from "@vite-hub/internal/http-request"
 import type { StreamEvent } from "./messages.ts"
+import type { StandardSchemaV1 } from "@standard-schema/spec"
 import type { WorkspaceName } from "@vite-hub/workspace"
 import { agentDiagnostics } from "./agent-diagnostics.ts"
+
+function isTriggerInputSchema<TInput>(input: string | StandardSchemaV1<unknown, TInput> | undefined): input is StandardSchemaV1<unknown, TInput> {
+  if (!isRuntimeRecord(input)) return false
+  const standard = input["~standard"]
+  return isRuntimeRecord(standard) && hasRuntimeType(standard.validate, "function")
+}
 
 const agentTriggerContextKey = "agent.trigger"
 
@@ -439,13 +447,14 @@ export async function resolveAgentTriggerInvocation<
     })
   }
   let validatedInput = input
-  if (trigger.input && "~standard" in Object(trigger.input)) {
+  if (isTriggerInputSchema(trigger.input)) {
     if (trigger.webhooks?.length && context.request) {
       const result = await trigger.input["~standard"].validate(input)
       if (result.issues?.length || !("value" in result)) {
         return {
           response: Response.json({ accepted: false, reason: "invalid_payload" }, { status: 400 }),
-          trigger,
+          // SAFETY: A handled invalid payload never invokes the trigger, so its validated input type remains opaque to consumers.
+          trigger: trigger as never,
         }
       }
       validatedInput = result.value

--- a/packages/agent/src/trigger-runtime.ts
+++ b/packages/agent/src/trigger-runtime.ts
@@ -35,7 +35,8 @@ import type { WorkspaceName } from "@vite-hub/workspace"
 import { agentDiagnostics } from "./agent-diagnostics.ts"
 
 function isTriggerInputSchema<TInput>(input: string | StandardSchemaV1<unknown, TInput> | undefined): input is StandardSchemaV1<unknown, TInput> {
-  if (!isRuntimeRecord(input)) return false
+  if (!isRuntimeRecord(input) && !hasRuntimeType(input, "function")) return false
+  if (!("~standard" in input)) return false
   const standard = input["~standard"]
   return isRuntimeRecord(standard) && hasRuntimeType(standard.validate, "function")
 }

--- a/packages/agent/src/trigger-runtime.ts
+++ b/packages/agent/src/trigger-runtime.ts
@@ -27,6 +27,7 @@ import type {
   ResolvedAgentRuntimeContext,
   ResolvedAgentTriggerDefinition,
 } from "./types.ts"
+import { parseStandardSchema } from "@vite-hub/internal/http-request"
 import type { StreamEvent } from "./messages.ts"
 import type { WorkspaceName } from "@vite-hub/workspace"
 import { agentDiagnostics } from "./agent-diagnostics.ts"
@@ -437,7 +438,21 @@ export async function resolveAgentTriggerInvocation<
       requireSecretHeader: requiresWebhookSecretHeader(trigger.webhooks),
     })
   }
-  return resolveAgentTriggerInvocationResult(await trigger.invoke(input), trigger)
+  let validatedInput = input
+  if (trigger.input && "~standard" in Object(trigger.input)) {
+    try {
+      validatedInput = await parseStandardSchema(trigger.input, input, `Agent trigger "${trigger.id}" input`) as TInput
+    } catch (error) {
+      if (trigger.webhooks?.length && context.request) {
+        return {
+          response: Response.json({ accepted: false, reason: "invalid_payload" }, { status: 400 }),
+          trigger: trigger as never,
+        }
+      }
+      throw error
+    }
+  }
+  return resolveAgentTriggerInvocationResult(await trigger.invoke(validatedInput), trigger)
 }
 
 export function resolveAgentTriggerInvocationResult<

--- a/packages/agent/src/types.ts
+++ b/packages/agent/src/types.ts
@@ -640,7 +640,7 @@ export interface AgentTriggerDefinition<
   TContext extends AgentCallbackContext<TRuntimeConfig> = AgentTriggerContext<TRuntimeConfig, Name>,
 > {
   health?: AgentHealthDescriptor
-  input?: unknown
+  input?: StandardSchemaV1<unknown, TInput>
   invoke: (context: TContext, input: TInput) => MaybePromise<AgentTriggerInvokeResult<CALL_OPTIONS>>
   output?: "events" | "ui-message-stream" | (string & {})
   webhooks?: AgentWebhookRegistrationDefinition<TRuntimeConfig>[]
@@ -655,7 +655,7 @@ export interface ResolvedAgentTriggerDefinition<
   channelId?: string
   definition: AgentTriggerDefinition<TRuntimeConfig, WorkspaceName, TInput, CALL_OPTIONS>
   id: `${string}.${string}`
-  input?: unknown
+  input?: StandardSchemaV1<unknown, TInput>
   invoke: (input: TInput) => MaybePromise<AgentTriggerInvokeResult<CALL_OPTIONS>>
   name: string
   output?: "events" | "ui-message-stream" | (string & {})

--- a/packages/agent/src/types.ts
+++ b/packages/agent/src/types.ts
@@ -640,7 +640,7 @@ export interface AgentTriggerDefinition<
   TContext extends AgentCallbackContext<TRuntimeConfig> = AgentTriggerContext<TRuntimeConfig, Name>,
 > {
   health?: AgentHealthDescriptor
-  input?: StandardSchemaV1<unknown, TInput>
+  input?: string | StandardSchemaV1<unknown, TInput>
   invoke: (context: TContext, input: TInput) => MaybePromise<AgentTriggerInvokeResult<CALL_OPTIONS>>
   output?: "events" | "ui-message-stream" | (string & {})
   webhooks?: AgentWebhookRegistrationDefinition<TRuntimeConfig>[]
@@ -655,7 +655,7 @@ export interface ResolvedAgentTriggerDefinition<
   channelId?: string
   definition: AgentTriggerDefinition<TRuntimeConfig, WorkspaceName, TInput, CALL_OPTIONS>
   id: `${string}.${string}`
-  input?: StandardSchemaV1<unknown, TInput>
+  input?: string | StandardSchemaV1<unknown, TInput>
   invoke: (input: TInput) => MaybePromise<AgentTriggerInvokeResult<CALL_OPTIONS>>
   name: string
   output?: "events" | "ui-message-stream" | (string & {})

--- a/packages/agent/src/vite/invocation-stream-endpoint.ts
+++ b/packages/agent/src/vite/invocation-stream-endpoint.ts
@@ -400,6 +400,12 @@ function selectedTrigger(entry: AgentInvocationStreamEntry, body: AgentInvocatio
 
 function triggerInput(trigger: ResolvedAgentTriggerDefinition, body: AgentInvocationStreamBody, signal: AbortSignal, run: AgentRunMetadata): unknown {
   const payload = payloadFromBody(body)
+  if (trigger.input && "~standard" in Object(trigger.input)) {
+    if (payload) return payload
+    const prompt = promptFromBody(body)
+    if (!prompt) throw new Response("Missing Agent Trigger payload. Pass --payload or prompt.", { status: 400 })
+    return { prompt }
+  }
   if (trigger.id !== "chat.message") {
     const prompt = promptFromBody(body)
     if (payload) {

--- a/packages/agent/src/vite/invocation-stream-endpoint.ts
+++ b/packages/agent/src/vite/invocation-stream-endpoint.ts
@@ -1,4 +1,5 @@
 import { join } from "node:path"
+import { hasRuntimeType } from "../internal/runtime-type.ts"
 
 import { createGitHubWorkspaceStore } from "@vite-hub/workspace/internal/stores/github"
 import { VITEHUB_SERVER_DIRS } from "@vite-hub/internal/build/vite"
@@ -401,8 +402,8 @@ function selectedTrigger(entry: AgentInvocationStreamEntry, body: AgentInvocatio
 function triggerInput(trigger: ResolvedAgentTriggerDefinition, body: AgentInvocationStreamBody, signal: AbortSignal, run: AgentRunMetadata): unknown {
   const payload = payloadFromBody(body)
   if (trigger.input && "~standard" in Object(trigger.input)) {
-    if (payload) return payload
     const prompt = promptFromBody(body)
+    if (payload) return withPayloadDefaults(payload, { prompt })
     if (!prompt) throw new Response("Missing Agent Trigger payload. Pass --payload or prompt.", { status: 400 })
     return { prompt }
   }
@@ -721,7 +722,21 @@ async function handleAgentInvocationStreamRequest(server: ViteDevServer, req: In
         const previewAgent = withDeliveryPreviewChannels(entry.agent, event => {
           if (!signal.aborted) emit(event)
         })
-        output = await streamAgentWithWorkspaceProgress(entry, emit, signal, async () => await streamAgent(previewAgent as never, { ...context, ...(invocation.run ? { run: invocation.run } : {}) } as never, withDevLoopAbortSignal(invocation.input, signal) as never, {
+        const input = trigger.input && "~standard" in Object(trigger.input)
+          ? {
+              ...invocation.input,
+              context: {
+                ...withPayloadDefaults(invocation.input.context || {}, {
+                  invokerProfileId: hasRuntimeType(body.invokerProfileId, "string") ? body.invokerProfileId : undefined,
+                }),
+                ...(isRecord(body.meta) ? {
+                  channel: withPayloadDefaults(isRecord(invocation.input.context?.channel) ? invocation.input.context.channel : {}, { meta: body.meta }),
+                } : {}),
+              },
+            }
+          : invocation.input
+        // SAFETY: The resolved trigger and preview Agent share the discovered Agent contract; only Dev Loop context defaults and cancellation are added.
+        output = await streamAgentWithWorkspaceProgress(entry, emit, signal, async () => await streamAgent(previewAgent as never, { ...context, ...(invocation.run ? { run: invocation.run } : {}) } as never, withDevLoopAbortSignal(input, signal) as never, {
           output: "events",
         }))
       }

--- a/packages/agent/test/discovery.test.ts
+++ b/packages/agent/test/discovery.test.ts
@@ -1334,20 +1334,31 @@ describe("agent chat capability discovery", () => {
     const { defineChannel, defineChannelTrigger } = await import("../src/channels.ts")
     const { defineAgent } = await import("../src/index.ts")
     const { agentInvocationStreamHeader, agentInvocationStreamHeaderValue, agentInvocationStreamRoute } = await import("../src/invocation-stream.ts")
-    const invoke = vi.fn((_context: unknown, input: { text: string }) => ({ input: { prompt: input.text } }))
+    const invoke = vi.fn((_context: unknown, input: { text: string, prompt: string }) => ({ input: { prompt: `${input.prompt}: ${input.text}` } }))
     const agent = defineAgent({
       channels: {
         review: defineChannel("review", {
           messages: false,
           triggers: {
             requested: defineChannelTrigger({
-              input: v.strictObject({ text: v.pipe(v.string(), v.trim()) }),
+              input: v.strictObject({ prompt: v.string(), text: v.pipe(v.string(), v.trim()) }),
               invoke,
             }),
           },
         }),
       },
-      driver: { run: ({ input }) => input.prompt },
+      invoker: {
+        profiles: [
+          { id: "default", kind: "customer", label: "Default" },
+          { id: "technical", kind: "technical", label: "Technical" },
+        ],
+      },
+      driver: { run: ({ input, invoker, context }) => {
+        expect(invoker.id).toBe("technical")
+        expect(context.get("channel")).toMatchObject({ meta: { source: "dev-loop" } })
+        expect(input.abortSignal).toBeInstanceOf(AbortSignal)
+        return input.prompt
+      } },
     })
     const { handlers, server } = createFakeServer(root, { default: agent })
     const plugin = (await import("../src/vite.ts")).hubAgent()
@@ -1357,6 +1368,9 @@ describe("agent chat capability discovery", () => {
       const response = await invokeMiddleware(handlers[0]!, {
         agent: "review",
         payload,
+        prompt: "Please review",
+        invokerProfileId: "technical",
+        meta: { source: "dev-loop" },
         trigger: "review.requested",
       }, agentInvocationStreamRoute, {
         "content-type": "application/json",
@@ -1366,11 +1380,11 @@ describe("agent chat capability discovery", () => {
       if ("unexpected" in payload) {
         expect(events).toContainEqual(expect.objectContaining({ type: "error" }))
       } else {
-        expect(events).toContainEqual({ text: "review this", type: "text-delta" })
+        expect(events).toContainEqual({ text: "Please review: review this", type: "text-delta" })
       }
     }
     expect(invoke).toHaveBeenCalledTimes(1)
-    expect(invoke).toHaveBeenCalledWith(expect.anything(), { text: "review this" })
+    expect(invoke).toHaveBeenCalledWith(expect.anything(), { prompt: "Please review", text: "review this" })
   })
 
   it("derives built-in GitHub webhook dev input from webhook payload", async () => {

--- a/packages/agent/test/discovery.test.ts
+++ b/packages/agent/test/discovery.test.ts
@@ -1368,7 +1368,7 @@ describe("agent chat capability discovery", () => {
       const response = await invokeMiddleware(handlers[0]!, {
         agent: "review",
         payload,
-        prompt: "Please review",
+        text: "Please review",
         invokerProfileId: "technical",
         meta: { source: "dev-loop" },
         trigger: "review.requested",

--- a/packages/agent/test/discovery.test.ts
+++ b/packages/agent/test/discovery.test.ts
@@ -1325,6 +1325,54 @@ describe("agent chat capability discovery", () => {
     ])
   })
 
+  it("validates strict typed Dev Loop payloads without runtime metadata", async () => {
+    const root = await createTempRoot("vitehub-agent-invocation-stream-typed-payload-")
+    await mkdir(join(root, "server", "agents"), { recursive: true })
+    await writeFile(join(root, "server", "agents", "review.ts"), "export default {}", "utf8")
+
+    const v = await import("valibot")
+    const { defineChannel, defineChannelTrigger } = await import("../src/channels.ts")
+    const { defineAgent } = await import("../src/index.ts")
+    const { agentInvocationStreamHeader, agentInvocationStreamHeaderValue, agentInvocationStreamRoute } = await import("../src/invocation-stream.ts")
+    const invoke = vi.fn((_context: unknown, input: { text: string }) => ({ input: { prompt: input.text } }))
+    const agent = defineAgent({
+      channels: {
+        review: defineChannel("review", {
+          messages: false,
+          triggers: {
+            requested: defineChannelTrigger({
+              input: v.strictObject({ text: v.pipe(v.string(), v.trim()) }),
+              invoke,
+            }),
+          },
+        }),
+      },
+      driver: { run: ({ input }) => input.prompt },
+    })
+    const { handlers, server } = createFakeServer(root, { default: agent })
+    const plugin = (await import("../src/vite.ts")).hubAgent()
+    await configurePluginServer(plugin, server)
+
+    for (const payload of [{ text: "  review this  " }, { text: "review this", unexpected: true }]) {
+      const response = await invokeMiddleware(handlers[0]!, {
+        agent: "review",
+        payload,
+        trigger: "review.requested",
+      }, agentInvocationStreamRoute, {
+        "content-type": "application/json",
+        [agentInvocationStreamHeader]: agentInvocationStreamHeaderValue,
+      })
+      const events = response.body.trim().split("\n").map(line => JSON.parse(line))
+      if ("unexpected" in payload) {
+        expect(events).toContainEqual(expect.objectContaining({ type: "error" }))
+      } else {
+        expect(events).toContainEqual({ text: "review this", type: "text-delta" })
+      }
+    }
+    expect(invoke).toHaveBeenCalledTimes(1)
+    expect(invoke).toHaveBeenCalledWith(expect.anything(), { text: "review this" })
+  })
+
   it("derives built-in GitHub webhook dev input from webhook payload", async () => {
     const root = await createTempRoot("vitehub-agent-invocation-stream-github-payload-")
     await mkdir(join(root, "server", "agents"), { recursive: true })

--- a/packages/agent/test/runtime.test.ts
+++ b/packages/agent/test/runtime.test.ts
@@ -3083,17 +3083,19 @@ describe("agent message protocol", () => {
     await expect(runAgentTrigger(agent, runtime, "portal.message", { text: "hello" })).resolves.toBe("channel:portal:hello")
   })
 
-  it("validates and transforms Standard Schema trigger input before invoke", async () => {
+  it.each([false, true])("validates and transforms Standard Schema trigger input before invoke (callable: %s)", async (callable) => {
     const { defineAgent, resolveAgentTriggerInvocation, runAgentTrigger } = await import("../src/index.ts")
     const { defineChannel, defineChannelTrigger } = await import("../src/channels.ts")
     const validation = vi.fn((value: string) => value.length > 0)
+    const schema = v.object({ payload: v.object({ text: v.pipe(v.string(), v.trim(), v.check(validation, "private validation detail")) }) })
+    const inputSchema = callable ? Object.assign(() => {}, { "~standard": schema["~standard"] }) : schema
     const agent = defineAgent({
       channels: {
         portal: defineChannel("portal", {
           messages: false,
           triggers: {
             webhook: defineChannelTrigger({
-              input: v.object({ payload: v.object({ text: v.pipe(v.string(), v.trim(), v.check(validation, "private validation detail")) }) }),
+              input: inputSchema,
               invoke: (_context, input) => ({ input: { prompt: input.payload.text } }),
               webhooks: [{ provider: "portal", secretHeader: "x-webhook-secret", secretToken: "secret" }],
             }),

--- a/packages/agent/test/runtime.test.ts
+++ b/packages/agent/test/runtime.test.ts
@@ -1,6 +1,7 @@
 import { asUnknownBoundary, hasRuntimeType, isRuntimeRecord } from "../src/internal/runtime-type.ts"
 import { generateKeyPairSync } from "node:crypto"
 import { afterEach, describe, expect, it, vi } from "vitest"
+import * as v from "valibot"
 
 import { createMessage, getMessageText } from "@vite-hub/agent"
 import { createTraceEventLog, deriveTraceRuns, emitTraceEvent, traceEventsToOpenTelemetrySpans, ViteHubError } from "@vite-hub/runtime"
@@ -3080,6 +3081,48 @@ describe("agent message protocol", () => {
       },
     })
     await expect(runAgentTrigger(agent, runtime, "portal.message", { text: "hello" })).resolves.toBe("channel:portal:hello")
+  })
+
+  it("validates and transforms Standard Schema trigger input before invoke", async () => {
+    const { defineAgent, resolveAgentTriggerInvocation, runAgentTrigger } = await import("../src/index.ts")
+    const { defineChannel, defineChannelTrigger } = await import("../src/channels.ts")
+    const validation = vi.fn((value: string) => value.length > 0)
+    const agent = defineAgent({
+      channels: {
+        portal: defineChannel("portal", {
+          messages: false,
+          triggers: {
+            webhook: defineChannelTrigger({
+              input: v.object({ payload: v.object({ text: v.pipe(v.string(), v.trim(), v.check(validation, "private validation detail")) }) }),
+              invoke: (_context, input) => ({ input: { prompt: input.payload.text } }),
+              webhooks: [{ provider: "portal", secretHeader: "x-webhook-secret", secretToken: "secret" }],
+            }),
+          },
+        }),
+      },
+      driver: { run: context => context.prompt },
+    })
+    const runtime = { memo: vi.fn(), runtime: "unknown" as const, waitUntil: vi.fn() }
+
+    await expect(runAgentTrigger(agent, runtime, "portal.webhook", { payload: { text: "  hello  " } })).resolves.toBe("hello")
+    validation.mockClear()
+    const invalid = await resolveAgentTriggerInvocation(agent, {
+      ...runtime,
+      request: new Request("https://example.test/webhook", { headers: { "x-webhook-secret": "secret" }, method: "POST" }),
+    }, "portal.webhook", { payload: { text: "" } })
+    expect("response" in invalid && invalid.response.status).toBe(400)
+    if ("response" in invalid) await expect(invalid.response.json()).resolves.toEqual({ accepted: false, reason: "invalid_payload" })
+    expect(validation).toHaveBeenCalledTimes(1)
+
+    validation.mockClear()
+    await expect(resolveAgentTriggerInvocation(agent, {
+      ...runtime,
+      request: new Request("https://example.test/webhook", { headers: { "x-webhook-secret": "wrong" }, method: "POST" }),
+    }, "portal.webhook", { payload: { text: "" } })).rejects.toMatchObject({
+      message: "[vitehub] Webhook secret verification failed.",
+      statusCode: 401,
+    })
+    expect(validation).not.toHaveBeenCalled()
   })
 
   it("adds only the active Channel Capabilities", async () => {

--- a/packages/agent/test/runtime.test.ts
+++ b/packages/agent/test/runtime.test.ts
@@ -3125,6 +3125,44 @@ describe("agent message protocol", () => {
     expect(validation).not.toHaveBeenCalled()
   })
 
+  it.each([false, true])("propagates webhook validator exceptions (async: %s)", async (asyncValidation) => {
+    const { defineAgent, resolveAgentTriggerInvocation } = await import("../src/index.ts")
+    const { defineChannel, defineChannelTrigger } = await import("../src/channels.ts")
+    const failure = new Error("broken validator")
+    const invoke = vi.fn(() => ({ input: { prompt: "unused" } }))
+    const agent = defineAgent({
+      channels: {
+        portal: defineChannel("portal", {
+          messages: false,
+          triggers: {
+            webhook: defineChannelTrigger({
+              input: {
+                "~standard": {
+                  version: 1,
+                  vendor: "test",
+                  validate() {
+                    if (asyncValidation) return Promise.reject(failure)
+                    throw failure
+                  },
+                },
+              },
+              invoke,
+              webhooks: [{ provider: "portal", secretHeader: "x-webhook-secret", secretToken: "secret" }],
+            }),
+          },
+        }),
+      },
+      driver: { run: context => context.prompt },
+    })
+    const runtime = { memo: vi.fn(), runtime: "unknown" as const, waitUntil: vi.fn() }
+
+    await expect(resolveAgentTriggerInvocation(agent, {
+      ...runtime,
+      request: new Request("https://example.test/webhook", { headers: { "x-webhook-secret": "secret" }, method: "POST" }),
+    }, "portal.webhook", { payload: { text: "hello" } })).rejects.toBe(failure)
+    expect(invoke).not.toHaveBeenCalled()
+  })
+
   it("adds only the active Channel Capabilities", async () => {
     const { defineAgent, defineCapability, runAgent, runAgentTrigger } = await import("../src/index.ts")
     const { openapi } = await import("../src/capabilities.ts")


### PR DESCRIPTION
Channel triggers can declare input types, but runtime invocation currently forwards unchecked values. This accepts Standard Schema input definitions, validates and transforms trigger input before invocation, and documents the typed trigger contract.\n\nValidation: the focused Standard Schema trigger test passed; the agent package build and publint passed.