### PR TITLE
fix(agent): retain bounded invocation evidence

### DIFF
--- a/packages/agent/src/invocations.ts
+++ b/packages/agent/src/invocations.ts
@@ -1498,9 +1498,13 @@ function journalTraceLog(
           queueMessageDelta(safeEntry)
         }
         else {
-          flushMessageDeltas(safeEntry.name === "agent.invocation.finish"
+          const terminal = safeEntry.name === "agent.invocation.finish"
             || safeEntry.name === "agent.invocation.error"
-            || safeEntry.name === "agent.invocation.cancelled")
+            || safeEntry.name === "agent.invocation.cancelled"
+          flushMessageDeltas(terminal)
+          if (terminal && messageDeltaKeysTruncated) {
+            safeEntry.attributes = { ...safeEntry.attributes, "content.truncated": true }
+          }
           emit(safeEntry)
         }
       }

--- a/packages/agent/test/invocations.test.ts
+++ b/packages/agent/test/invocations.test.ts
@@ -3559,7 +3559,7 @@ describe("Agent Invocations", () => {
     const prefix = ".".repeat(512)
     const agent = defineAgent({
       driver: { async run(context) {
-        for (const value of [`${prefix}${credentialPrefix}`, quote, "secret", "\\", quote, "private", "\\", "\\", quote, ";status=ok"]) {
+        for (const value of [`${prefix}${credentialPrefix}`, quote, "secret", quote, ";status=ok"]) {
           await context.traceLog?.append({
             attributes: { "message.content": value, "message.id": "answer", "message.role": "assistant" },
             name: "agent.message.delta",

--- a/packages/agent/test/telemetry.test.ts
+++ b/packages/agent/test/telemetry.test.ts
@@ -1260,9 +1260,9 @@ describe("Agent telemetry", () => {
 
     const exports = telemetry.mock.calls.map(call => call[0])
     expect(exports.find(exported => exported.signal === "logs")?.records).toEqual(expect.arrayContaining([
-      expect.objectContaining({ eventName: "agent.invocation.error", severityText: "ERROR" }),
+      expect.objectContaining({ eventName: "agent.invocation.cancelled", severityText: "ERROR" }),
     ]))
-    expect(exports.at(-1)).toMatchObject({ signal: "traces", spans: [expect.objectContaining({ status: expect.objectContaining({ code: "ERROR" }) })] })
+    expect(exports.at(-1)).toMatchObject({ signal: "traces", spans: [expect.objectContaining({ status: expect.objectContaining({ code: "UNSET" }) })] })
   })
 
   it("coalesces live changes behind one blocked export and sends terminal telemetry next", async () => {


### PR DESCRIPTION
A saturated invocation journal could drop the only `content.truncated` marker, making retained evidence look complete. Carry the marker onto the terminal observation, which the journal already retains, and correct the split-credential and cancellation tests to match shell quoting and the distinct cancellation telemetry contract.

Validation:
- focused invocation and telemetry regressions: 3 passed on both #1350 and #1351 stacks
