### PR TITLE
fix(agent): preserve telemetry warning severity and tool timing

### DIFF
--- a/packages/agent/src/trace.ts
+++ b/packages/agent/src/trace.ts
@@ -485,10 +485,27 @@ function isAgentDataStreamEvent(event: StreamEvent): event is AgentDataStreamEve
   return event.type === "data-agent-event"
 }
 
+function createStreamTraceTiming<TRuntimeConfig extends AgentRuntimeConfig>(context: AgentTraceContext<TRuntimeConfig>) {
+  let tracingMs = 0
+  return {
+    track: createToolDurationTracker(() => Date.now() - tracingMs),
+    async trace(event: StreamEvent) {
+      const startedAt = Date.now()
+      try {
+        await traceAgentStreamEvent(context, event)
+      }
+      finally {
+        // Callers await tracing before observing the next provider event.
+        tracingMs += Math.max(0, Date.now() - startedAt)
+      }
+    },
+  }
+}
+
 export function createAgentStreamEventTracer<TRuntimeConfig extends AgentRuntimeConfig>(
   context: AgentTraceContext<TRuntimeConfig>,
 ) {
-  const trackToolDuration = createToolDurationTracker()
+  const timing = createStreamTraceTiming(context)
   let pendingText: Extract<StreamEvent, { type: "text-delta" }> | undefined
   let pendingCommandOutput: AgentDataStreamEvent | undefined
   const flush = async () => {
@@ -496,12 +513,13 @@ export function createAgentStreamEventTracer<TRuntimeConfig extends AgentRuntime
     pendingText = undefined
     pendingCommandOutput = undefined
     for (const event of events) {
-      if (event) await traceAgentStreamEvent(context, event)
+      if (event) await timing.trace(event)
     }
   }
   return {
     flush,
     async write(event: StreamEvent) {
+      const tracedEvent = timing.track(event)
       const data = event.type === "data-agent-event" ? record(event.data) : undefined
       const value = record(data?.value)
       if (isAgentDataStreamEvent(event) && data?.kind === "content.delta" && value?.streamKind === "command_output" && hasRuntimeType(value.delta, "string")) {
@@ -523,7 +541,7 @@ export function createAgentStreamEventTracer<TRuntimeConfig extends AgentRuntime
       }
       if (event.type !== "text-delta" || !hasRuntimeType(event.text, "string")) {
         await flush()
-        await traceAgentStreamEvent(context, trackToolDuration(event))
+        await timing.trace(tracedEvent)
         return
       }
       if (pendingText
@@ -559,9 +577,10 @@ export function traceAgentStreamEvents<TRuntimeConfig extends AgentRuntimeConfig
   context: AgentTraceContext<TRuntimeConfig>,
 ): AsyncIterable<StreamEvent> {
   return (async function* () {
-    const trackToolDuration = createToolDurationTracker()
+    const timing = createStreamTraceTiming(context)
     for await (const event of events) {
-      await traceAgentStreamEvent(context, trackToolDuration(event as StreamEvent))
+      // SAFETY: Provider stream events follow the stream event contract.
+      await timing.trace(timing.track(event as StreamEvent))
       // SAFETY: Trace normalization establishes the asserted telemetry event contract.
       yield event as StreamEvent
     }

--- a/packages/agent/src/trace.ts
+++ b/packages/agent/src/trace.ts
@@ -579,8 +579,10 @@ export function traceAgentStreamEvents<TRuntimeConfig extends AgentRuntimeConfig
   return (async function* () {
     const timing = createStreamTraceTiming(context)
     for await (const event of events) {
-      // SAFETY: Provider stream events follow the stream event contract.
-      await timing.trace(timing.track(event as StreamEvent))
+      if (isRuntimeRecord(event) && hasRuntimeType(event.type, "string")) {
+        // SAFETY: The runtime guard establishes the stream event shape used by tracing.
+        await timing.trace(timing.track(event as StreamEvent))
+      }
       // SAFETY: Trace normalization establishes the asserted telemetry event contract.
       yield event as StreamEvent
     }

--- a/packages/agent/src/trace.ts
+++ b/packages/agent/src/trace.ts
@@ -181,6 +181,25 @@ function eventAttributes(event: StreamEvent): Record<string, unknown> {
   return {}
 }
 
+export function createToolDurationTracker(now: () => number = Date.now): (event: StreamEvent) => StreamEvent {
+  const startedAt = new Map<string, number>()
+  return (event) => {
+    if (event.type === "tool-call") {
+      if (!startedAt.has(event.id)) startedAt.set(event.id, now())
+      return event
+    }
+    if (event.type !== "tool-result") return event
+    const start = startedAt.get(event.id)
+    startedAt.delete(event.id)
+    if (typeof event.durationMs === "number" && Number.isFinite(event.durationMs) && event.durationMs > 0) return event
+    if (start === undefined) {
+      const { durationMs: _durationMs, ...result } = event
+      return result
+    }
+    return { ...event, durationMs: Math.max(0, now() - start) }
+  }
+}
+
 function toolCapabilityId(
   contributions: readonly AgentDriverContribution[] | undefined,
   toolName: unknown,
@@ -469,6 +488,7 @@ function isAgentDataStreamEvent(event: StreamEvent): event is AgentDataStreamEve
 export function createAgentStreamEventTracer<TRuntimeConfig extends AgentRuntimeConfig>(
   context: AgentTraceContext<TRuntimeConfig>,
 ) {
+  const trackToolDuration = createToolDurationTracker()
   let pendingText: Extract<StreamEvent, { type: "text-delta" }> | undefined
   let pendingCommandOutput: AgentDataStreamEvent | undefined
   const flush = async () => {
@@ -503,7 +523,7 @@ export function createAgentStreamEventTracer<TRuntimeConfig extends AgentRuntime
       }
       if (event.type !== "text-delta" || !hasRuntimeType(event.text, "string")) {
         await flush()
-        await traceAgentStreamEvent(context, event)
+        await traceAgentStreamEvent(context, trackToolDuration(event))
         return
       }
       if (pendingText
@@ -539,8 +559,9 @@ export function traceAgentStreamEvents<TRuntimeConfig extends AgentRuntimeConfig
   context: AgentTraceContext<TRuntimeConfig>,
 ): AsyncIterable<StreamEvent> {
   return (async function* () {
+    const trackToolDuration = createToolDurationTracker()
     for await (const event of events) {
-      await traceAgentStreamEvent(context, event)
+      await traceAgentStreamEvent(context, trackToolDuration(event as StreamEvent))
       // SAFETY: Trace normalization establishes the asserted telemetry event contract.
       yield event as StreamEvent
     }

--- a/packages/agent/src/trace.ts
+++ b/packages/agent/src/trace.ts
@@ -191,7 +191,7 @@ export function createToolDurationTracker(now: () => number = Date.now): (event:
     if (event.type !== "tool-result") return event
     const start = startedAt.get(event.id)
     startedAt.delete(event.id)
-    if (typeof event.durationMs === "number" && Number.isFinite(event.durationMs) && event.durationMs > 0) return event
+    if (hasRuntimeType(event.durationMs, "number") && Number.isFinite(event.durationMs) && event.durationMs > 0) return event
     if (start === undefined) {
       const { durationMs: _durationMs, ...result } = event
       return result

--- a/packages/agent/test/trace.test.ts
+++ b/packages/agent/test/trace.test.ts
@@ -7,6 +7,25 @@ import type { StreamEvent } from "../src/messages.ts"
 import { type AgentTraceContext, createAgentStreamEventTracer, createToolDurationTracker, traceAgentStreamEvents } from "../src/trace.ts"
 
 describe("Agent stream trace", () => {
+  it("passes malformed chunks through without interrupting tracing valid events", async () => {
+    const traceLog = createTraceEventLog({ content: "content" })
+    // SAFETY: Stream tracing only reads the context store and runtime trace fields.
+    const context = { context: createAgentInvocationContextStore(), runtime: { traceLog } } as AgentTraceContext
+    const chunks: unknown[] = [null, undefined, false, 42, "text", {}, { type: 42 },
+      { id: "tool-1", name: "shell", type: "tool-call" },
+      { durationMs: 42, id: "tool-1", name: "shell", type: "tool-result" }]
+    async function* events(): AsyncIterable<unknown> {
+      yield* chunks
+    }
+
+    const yielded = []
+    for await (const event of traceAgentStreamEvents(events(), context)) yielded.push(event)
+
+    expect(yielded).toEqual(chunks)
+    expect(traceLog.entries().map(event => event.name)).toEqual(["agent.tool.start", "agent.tool.finish"])
+    expect(traceLog.entries().at(-1)).toMatchObject({ attributes: { "tool.durationMs": 42 } })
+  })
+
   it("measures a tool result from its observed start when the provider reports zero", () => {
     let now = 1_000
     const track = createToolDurationTracker(() => now)

--- a/packages/agent/test/trace.test.ts
+++ b/packages/agent/test/trace.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from "vitest"
+
+import { createToolDurationTracker } from "../src/trace.ts"
+
+describe("Agent stream trace", () => {
+  it("measures a tool result from its observed start when the provider reports zero", () => {
+    let now = 1_000
+    const track = createToolDurationTracker(() => now)
+    track({ id: "tool-1", name: "shell", type: "tool-call" })
+    now = 1_750
+
+    expect(track({ durationMs: 0, id: "tool-1", name: "shell", type: "tool-result" }))
+      .toMatchObject({ durationMs: 750 })
+  })
+
+  it("keeps an unobserved zero tool duration unknown", () => {
+    const track = createToolDurationTracker(() => 1_000)
+
+    expect(track({ durationMs: 0, id: "tool-1", name: "shell", type: "tool-result" }))
+      .not.toHaveProperty("durationMs", 0)
+  })
+
+  it("preserves a positive provider tool duration", () => {
+    const track = createToolDurationTracker(() => 1_000)
+    track({ id: "tool-1", name: "shell", type: "tool-input-start" })
+
+    expect(track({ durationMs: 42, id: "tool-1", name: "shell", type: "tool-result" }))
+      .toMatchObject({ durationMs: 42 })
+  })
+
+  it("does not count tool input streaming as execution time", () => {
+    let now = 1_000
+    const track = createToolDurationTracker(() => now)
+    track({ id: "tool-1", name: "shell", type: "tool-input-start" })
+    now = 1_750
+
+    expect(track({ durationMs: 0, id: "tool-1", name: "shell", type: "tool-result" }))
+      .not.toHaveProperty("durationMs")
+  })
+})

--- a/packages/agent/test/trace.test.ts
+++ b/packages/agent/test/trace.test.ts
@@ -1,6 +1,10 @@
-import { describe, expect, it } from "vitest"
+import { describe, expect, it, vi } from "vitest"
 
-import { createToolDurationTracker } from "../src/trace.ts"
+import { createTraceEventLog } from "@vite-hub/runtime"
+
+import { createAgentInvocationContextStore } from "../src/invocation-context.ts"
+import type { StreamEvent } from "../src/messages.ts"
+import { type AgentTraceContext, createAgentStreamEventTracer, createToolDurationTracker, traceAgentStreamEvents } from "../src/trace.ts"
 
 describe("Agent stream trace", () => {
   it("measures a tool result from its observed start when the provider reports zero", () => {
@@ -36,5 +40,48 @@ describe("Agent stream trace", () => {
 
     expect(track({ durationMs: 0, id: "tool-1", name: "shell", type: "tool-result" }))
       .not.toHaveProperty("durationMs")
+  })
+})
+
+describe("tool timing with telemetry backpressure", () => {
+  it.each(["buffered", "iterable"] as const)("excludes slow sinks and buffered flushes in the %s path", async (path) => {
+    let now = 1_000
+    const clock = vi.spyOn(Date, "now").mockImplementation(() => now)
+    const traceLog = createTraceEventLog({
+      content: "content",
+      async onEntry() {
+        await Promise.resolve()
+        now += 5_000
+      },
+    })
+    // SAFETY: Stream tracing only reads the context store and runtime trace fields.
+    const context = { context: createAgentInvocationContextStore(), runtime: { traceLog } } as AgentTraceContext
+    const result: StreamEvent = { durationMs: 0, id: "tool-1", name: "shell", type: "tool-result" }
+    async function* events(): AsyncIterable<StreamEvent> {
+      yield { id: "text-1", text: "before", type: "text-delta" }
+      yield { id: "tool-1", name: "shell", type: "tool-call" }
+      now += 250
+      yield { data: { kind: "content.delta", value: { delta: "output", streamKind: "command_output" } }, id: "tool-1", type: "data-agent-event" }
+      now += 500
+      yield result
+    }
+    try {
+      if (path === "buffered") {
+        const tracer = createAgentStreamEventTracer(context)
+        for await (const event of events()) await tracer.write(event)
+        await tracer.flush()
+      }
+      else {
+        const yielded = []
+        for await (const event of traceAgentStreamEvents(events(), context)) yielded.push(event)
+        expect(yielded.at(-1)).toBe(result)
+      }
+      expect(traceLog.entries().find(event => event.name === "agent.tool.finish"))
+        .toMatchObject({ attributes: { "tool.durationMs": 750 } })
+      expect(result.durationMs).toBe(0)
+    }
+    finally {
+      clock.mockRestore()
+    }
   })
 })

--- a/packages/runtime/src/index.ts
+++ b/packages/runtime/src/index.ts
@@ -983,7 +983,8 @@ export function traceEventsToOpenTelemetryLogRecords(events: Iterable<TraceEvent
     return run.events.map((event) => {
       const id = stepId(event)
       const attributes = traceEventAttributes(event, options.content === "metadata" ? "metadata" : "content")
-      const error = event.type === "error" || /\.(?:cancelled|error|failed)$/.test(event.name)
+      const warning = event.name === "agent.stream.error" && event.attributes?.["error.recoverable"] === true
+      const error = !warning && (event.type === "error" || /\.(?:cancelled|error|failed)$/.test(event.name))
       return {
         attributes: {
           ...attributes,
@@ -993,7 +994,11 @@ export function traceEventsToOpenTelemetryLogRecords(events: Iterable<TraceEvent
           ...(id ? { "vitehub.step.id": id } : {}),
         },
         eventName: event.name,
-        ...(error ? { severityNumber: 17, severityText: "ERROR" } : {}),
+        ...(warning
+          ? { severityNumber: 13, severityText: "WARN" }
+          : error
+            ? { severityNumber: 17, severityText: "ERROR" }
+            : {}),
         spanId: id ? openTelemetryId(`${spanId}:${id}`, 16) : spanId,
         time: event.timestamp,
         traceId,

--- a/packages/runtime/test/runtime.test.ts
+++ b/packages/runtime/test/runtime.test.ts
@@ -1796,6 +1796,28 @@ describe("@vite-hub/runtime", () => {
     })
   })
 
+  it("exports recoverable stream errors as warnings with error metadata", () => {
+    const [record] = traceEventsToOpenTelemetryLogRecords([{
+      attributes: { "error.message": "Project config was skipped", "error.recoverable": true },
+      name: "agent.stream.error",
+      sequence: 1,
+      timestamp: "2026-01-01T00:00:00.000Z",
+      trace: { id: "run-1" },
+      type: "error",
+    }])
+
+    expect(record).toMatchObject({
+      attributes: {
+        "error.message": "Project config was skipped",
+        "error.recoverable": true,
+        "vitehub.event.type": "error",
+      },
+      eventName: "agent.stream.error",
+      severityNumber: 13,
+      severityText: "WARN",
+    })
+  })
+
   it("keeps provider activity open through progress and fails terminal task errors", () => {
     const events = [
       // SAFETY: This test fixture intentionally constructs the exact asserted runtime contract.


### PR DESCRIPTION
Providers can report a zero tool duration even when ViteHub observed the tool lifecycle, which makes real executions look instantaneous. Recoverable stream errors also retain error severity in OTLP even though Console correctly presents them as recovered warnings.

Track actual `tool-call` start times and use elapsed wall time when a provider reports zero. A result without an observed start remains unknown, and positive provider durations remain authoritative. Export recoverable `agent.stream.error` records at WARN severity while preserving the original event type and error metadata for Console inspection.

Validated with focused Agent and runtime tests, package typechecks, affected builds, and repository lint. The full provider suite passed 204/205 tests; its unrelated process-group escalation test timed out with a null child status.

Model: GPT-6 Codex. Harness: ViteHub `vp test`, `vp pack`, TypeScript, and oxlint.
