### PR TITLE
fix(agent): classify HTTP client errors as warnings

### DIFF
--- a/packages/agent/src/evlog.ts
+++ b/packages/agent/src/evlog.ts
@@ -1,4 +1,4 @@
-import { hasRuntimeType } from "./internal/runtime-type.ts"
+import { hasRuntimeType, isRuntimeRecord } from "./internal/runtime-type.ts"
 import { createLogger, type DrainContext, type WideEvent } from "evlog"
 import { createDrainPipeline } from "evlog/pipeline"
 import { withExportDeadline } from "./internal/export-deadline.ts"
@@ -274,9 +274,9 @@ export interface AgentEvlogHost {
 
 export function agentEvlogPlugin(telemetry: AgentEvlog, reporters: readonly { start(): void; stop(): Promise<void> }[] = []): (host: AgentEvlogHost) => void {
   const statusCodeOf = (error: unknown) => {
-    if (!error || typeof error !== "object") return undefined
-    const value = (error as { statusCode?: unknown, status?: unknown }).statusCode ?? (error as { status?: unknown }).status
-    return typeof value === "number" && Number.isInteger(value) ? value : undefined
+    if (!isRuntimeRecord(error)) return undefined
+    const value = error.statusCode ?? error.status
+    return hasRuntimeType(value, "number") && Number.isInteger(value) ? value : undefined
   }
   return (host) => {
     host.hooks.hook("request", event => {
@@ -296,7 +296,7 @@ export function agentEvlogPlugin(telemetry: AgentEvlog, reporters: readonly { st
       }
       // Client errors are expected request outcomes. Keep them visible as warning
       // events without creating PostHog exception noise or fake failures.
-      if (status !== undefined && status >= 400 && status < 500) {
+      if (request && status !== undefined && status >= 400 && status < 500) {
         telemetry.event("http.request.failed", { ...properties, level: "warn" })
       } else telemetry.exception(error, properties)
     })

--- a/packages/agent/src/evlog.ts
+++ b/packages/agent/src/evlog.ts
@@ -273,6 +273,11 @@ export interface AgentEvlogHost {
 }
 
 export function agentEvlogPlugin(telemetry: AgentEvlog, reporters: readonly { start(): void; stop(): Promise<void> }[] = []): (host: AgentEvlogHost) => void {
+  const statusCodeOf = (error: unknown) => {
+    if (!error || typeof error !== "object") return undefined
+    const value = (error as { statusCode?: unknown, status?: unknown }).statusCode ?? (error as { status?: unknown }).status
+    return typeof value === "number" && Number.isInteger(value) ? value : undefined
+  }
   return (host) => {
     host.hooks.hook("request", event => {
       event.req.context ||= {}
@@ -281,12 +286,19 @@ export function agentEvlogPlugin(telemetry: AgentEvlog, reporters: readonly { st
     host.hooks.hook("evlog:drain", telemetry.drain)
     host.hooks.hook("error", (error, context) => {
       const request = context.event?.req
-      telemetry.exception(error, {
+      const status = statusCodeOf(error)
+      const properties = {
         operation: "http.request",
         method: request?.method,
         path: request ? new URL(request.url).pathname : undefined,
         request_id: request?.context?.requestId,
-      })
+        status_code: status,
+      }
+      // Client errors are expected request outcomes. Keep them visible as warning
+      // events without creating PostHog exception noise or fake failures.
+      if (status !== undefined && status >= 400 && status < 500) {
+        telemetry.event("http.request.failed", { ...properties, level: "warn" })
+      } else telemetry.exception(error, properties)
     })
     if (telemetry.status().configured) for (const reporter of reporters) reporter.start()
     host.hooks.hook("close", async () => {

--- a/packages/agent/src/evlog.ts
+++ b/packages/agent/src/evlog.ts
@@ -1,4 +1,5 @@
-import { hasRuntimeType, isRuntimeRecord } from "./internal/runtime-type.ts"
+import { readAgentErrorProperty } from "./agent-error.ts"
+import { hasRuntimeType } from "./internal/runtime-type.ts"
 import { createLogger, type DrainContext, type WideEvent } from "evlog"
 import { createDrainPipeline } from "evlog/pipeline"
 import { withExportDeadline } from "./internal/export-deadline.ts"
@@ -57,7 +58,7 @@ export interface AgentEvlog {
   flush(): Promise<void>
 }
 
-const minimalKeys = /^(?:agent_name|environment|service|run_id|invocation_id|thread_id|trace_id|parent_trace_id|\$ai_trace_id|session_url|model|provider|provider_name|status|level|severity|duration_ms|timestamp|started_at|ended_at|input_tokens|output_tokens|total_tokens|cost_usd|cost_estimated|cost_source|tool_steps|retry|attempt|reason|code|diagnostic_code|diagnostic_status|warning|error|message)$/i
+const minimalKeys = /^(?:agent_name|environment|service|run_id|invocation_id|thread_id|trace_id|parent_trace_id|\$ai_trace_id|session_url|model|provider|provider_name|status_code|request_id|method|path|operation|status|level|severity|duration_ms|timestamp|started_at|ended_at|input_tokens|output_tokens|total_tokens|cost_usd|cost_estimated|cost_source|tool_steps|retry|attempt|reason|code|diagnostic_code|diagnostic_status|warning|error|message)$/i
 const contentKeys = /(?:prompt|message|input|output|instruction|tool|argument|result|body|context|header|cookie|token|secret|credential)/i
 
 /** Apply the configured observability level before exporter delivery. */
@@ -274,8 +275,7 @@ export interface AgentEvlogHost {
 
 export function agentEvlogPlugin(telemetry: AgentEvlog, reporters: readonly { start(): void; stop(): Promise<void> }[] = []): (host: AgentEvlogHost) => void {
   const statusCodeOf = (error: unknown) => {
-    if (!isRuntimeRecord(error)) return undefined
-    const value = error.statusCode ?? error.status
+    const value = readAgentErrorProperty(error, "statusCode") ?? readAgentErrorProperty(error, "status")
     return hasRuntimeType(value, "number") && Number.isInteger(value) ? value : undefined
   }
   return (host) => {

--- a/packages/agent/test/evlog.test.ts
+++ b/packages/agent/test/evlog.test.ts
@@ -203,6 +203,16 @@ it("logs HTTP 4xx failures as warnings without exporting exceptions", async () =
   expect(exporter.capture).toHaveBeenCalledWith("http.request.failed", expect.objectContaining({ level: "warn", status_code: 404, request_id: "req-1" }), expect.anything())
 })
 
+it("keeps non-request 4xx failures as exceptions", async () => {
+  const { telemetry, exporter } = setup()
+  const hooks = new Map<string, Function>()
+  agentEvlogPlugin(telemetry)({ hooks: { hook(name, callback) { hooks.set(name, callback) } } })
+  hooks.get("error")!(Object.assign(new Error("Upstream rejected background task"), { statusCode: 403 }), {})
+  await telemetry.flush()
+  expect(exporter.exception).toHaveBeenCalledTimes(1)
+  expect(exporter.capture).not.toHaveBeenCalled()
+})
+
 it.each([500, 503])( "keeps HTTP %s failures as exceptions", async (statusCode) => {
   const { telemetry, exporter } = setup()
   const hooks = new Map<string, Function>()

--- a/packages/agent/test/evlog.test.ts
+++ b/packages/agent/test/evlog.test.ts
@@ -192,15 +192,15 @@ it.each(["failures", "all", false] as const)("preserves application logs with HT
   expect(records.filter(record => !record.event).map(record => record.status)).toEqual(logs === "all" ? [200, 500] : logs === "failures" ? [500] : [])
 })
 
-it("logs HTTP 4xx failures as warnings without exporting exceptions", async () => {
-  const { telemetry, exporter } = setup()
+it.each(["minimal", "standard", "full"] as const)("logs HTTP 4xx failures with request metadata at %s level", async (level) => {
+  const { telemetry, exporter } = setup({}, { level, logs: false })
   const hooks = new Map<string, Function>()
   agentEvlogPlugin(telemetry)({ hooks: { hook(name, callback) { hooks.set(name, callback) } } })
-  const req = Object.assign(new Request("https://example.test/missing"), { context: { requestId: "req-1" } })
+  const req = Object.assign(new Request("https://example.test/missing?token=secret"), { context: { requestId: "req-1" } })
   hooks.get("error")!(Object.assign(new Error("Not found"), { statusCode: 404 }), { event: { req } })
   await telemetry.flush()
   expect(exporter.exception).not.toHaveBeenCalled()
-  expect(exporter.capture).toHaveBeenCalledWith("http.request.failed", expect.objectContaining({ level: "warn", status_code: 404, request_id: "req-1" }), expect.anything())
+  expect(exporter.capture).toHaveBeenCalledWith("http.request.failed", expect.objectContaining({ level: "warn", status_code: 404, request_id: "req-1", method: "GET", path: "/missing", operation: "http.request" }), expect.anything())
 })
 
 it("keeps non-request 4xx failures as exceptions", async () => {
@@ -221,4 +221,18 @@ it.each([500, 503])( "keeps HTTP %s failures as exceptions", async (statusCode) 
   hooks.get("error")!(Object.assign(new Error("Server error"), { statusCode }), { event: { req } })
   await telemetry.flush()
   expect(exporter.exception).toHaveBeenCalledTimes(1)
+})
+
+it.each(["statusCode", "status"])("keeps errors with a throwing %s getter on the exception path", async (property) => {
+  const { telemetry, exporter } = setup()
+  const hooks = new Map<string, Function>()
+  agentEvlogPlugin(telemetry)({ hooks: { hook(name, callback) { hooks.set(name, callback) } } })
+  const error = Object.defineProperty(new Error("Unknown failure"), property, {
+    get() { throw new Error("Cannot inspect status") },
+  })
+  const req = new Request("https://example.test/fail")
+  expect(() => hooks.get("error")!(error, { event: { req } })).not.toThrow()
+  await telemetry.flush()
+  expect(exporter.exception).toHaveBeenCalledTimes(1)
+  expect(exporter.capture).not.toHaveBeenCalled()
 })

--- a/packages/agent/test/evlog.test.ts
+++ b/packages/agent/test/evlog.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, expect, it, vi } from "vitest"
 import { initLogger } from "evlog"
-import { createAgentEvlog, filterAgentObservability, sanitizeAgentLog, type AgentEvlogExporter } from "../src/evlog.ts"
+import { agentEvlogPlugin, createAgentEvlog, filterAgentObservability, sanitizeAgentLog, type AgentEvlogExporter } from "../src/evlog.ts"
 import { defineAgent, runAgent } from "../src/index.ts"
 
 const background: Promise<unknown>[] = []
@@ -190,4 +190,25 @@ it.each(["failures", "all", false] as const)("preserves application logs with HT
   const records = exporter.logs.mock.calls[0]![0]
   expect(records.filter(record => record.event).map(record => record.event)).toEqual(["job.finished", "job.progress", "outbound.finished"])
   expect(records.filter(record => !record.event).map(record => record.status)).toEqual(logs === "all" ? [200, 500] : logs === "failures" ? [500] : [])
+})
+
+it("logs HTTP 4xx failures as warnings without exporting exceptions", async () => {
+  const { telemetry, exporter } = setup()
+  const hooks = new Map<string, Function>()
+  agentEvlogPlugin(telemetry)({ hooks: { hook(name, callback) { hooks.set(name, callback) } } })
+  const req = Object.assign(new Request("https://example.test/missing"), { context: { requestId: "req-1" } })
+  hooks.get("error")!(Object.assign(new Error("Not found"), { statusCode: 404 }), { event: { req } })
+  await telemetry.flush()
+  expect(exporter.exception).not.toHaveBeenCalled()
+  expect(exporter.capture).toHaveBeenCalledWith("http.request.failed", expect.objectContaining({ level: "warn", status_code: 404, request_id: "req-1" }), expect.anything())
+})
+
+it.each([500, 503])( "keeps HTTP %s failures as exceptions", async (statusCode) => {
+  const { telemetry, exporter } = setup()
+  const hooks = new Map<string, Function>()
+  agentEvlogPlugin(telemetry)({ hooks: { hook(name, callback) { hooks.set(name, callback) } } })
+  const req = Object.assign(new Request("https://example.test/fail"), { context: { requestId: "req-5xx" } })
+  hooks.get("error")!(Object.assign(new Error("Server error"), { statusCode }), { event: { req } })
+  await telemetry.flush()
+  expect(exporter.exception).toHaveBeenCalledTimes(1)
 })


### PR DESCRIPTION
HTTP 4xx responses are expected request outcomes but were exported as exceptions. Emit a warning event with status/request metadata for 4xx while retaining exception telemetry for 5xx and unknown errors. Adds regression coverage for 404, 500, and 503.