### PR TITLE
feat(vite-hub): configure Node storage with one data directory

### DIFF
--- a/docs/content/docs/concepts/vite-integrations-and-provider-output.md
+++ b/docs/content/docs/concepts/vite-integrations-and-provider-output.md
@@ -37,3 +37,25 @@ Inspect generated output to verify routes, bindings, or host wiring. Import it f
 | Server code access | A documented package or generated import. |
 
 Read [Definition discovery](/docs/concepts/definitions-and-discovery), [Runtime Helpers and stable imports](/docs/concepts/runtime-helpers-and-stable-imports), and [Provider Output](/docs/reference/provider-output) for more detail.
+
+## Persistent Node storage
+
+Set `dataDir` in `vitehub()` to select a shared local storage directory on a Node host:
+
+```ts
+vitehub({
+  preset: "node",
+  dataDir: "/var/lib/app",
+  agent: true,
+  console: { exposure: "host-managed" },
+  kv: true,
+  blob: true,
+  workspace: true,
+})
+```
+
+Enabled integrations use `agent-state.sqlite`, `console.sqlite`, `kv/`, `blob/`, and `workspaces/` under this directory. Named local KV and Blob stores get separate subdirectories. Explicit paths and remote providers take precedence; disabled services stay disabled. Relative paths resolve from the configuration process's working directory.
+
+The host must provide a persistent, writable filesystem at this path. The option does not create a volume or make an ephemeral filesystem durable, and it is rejected for other presets. Keep the existing provider configuration for hosted storage.
+
+Use `agent.providers.state.url`, `console.databaseUrl`, or each store's path option to preserve an existing location. Existing runtime database URL overrides still take precedence. Changing the directory does not migrate stored data.

--- a/packages/vite-hub/README.md
+++ b/packages/vite-hub/README.md
@@ -28,6 +28,10 @@ export default defineConfig({
 
 This registers ViteHub's build integration. Your application still needs a server entry or a framework such as Nuxt. For Nuxt, use the `vite-hub/nuxt` module shown in the [installation guide](https://vitehub.dev/docs/getting-started/installation).
 
+On a Node host with persistent storage, set `dataDir` once. Enabled Agent State, Console, KV, Blob, and Workspace integrations derive local paths from it. For example, `vitehub({ preset: "node", dataDir: "/var/lib/app", agent: true, kv: true, blob: true, workspace: true })` uses that directory without per-store environment variables. Relative paths resolve from the configuration process's working directory. The host must mount persistent storage there; `dataDir` does not create a volume. Other presets require their own storage providers.
+
+Explicit store paths, remote URLs, and disabled services remain authoritative. Set `console.databaseUrl` to preserve an existing journal location; `VITEHUB_CONSOLE_DATABASE_URL` remains a runtime override. Changing paths does not migrate existing data.
+
 ## Run a complete first result
 
 Choose the result that matches the application you are building:

--- a/packages/vite-hub/src/console/plugin.ts
+++ b/packages/vite-hub/src/console/plugin.ts
@@ -26,6 +26,7 @@ function renderConsoleNitroPlugin(
   runtimeBinding?: string,
   invoke = false,
   observations?: AgentInvocationsOptions["observations"],
+  databaseUrl?: string,
 ): string {
   const definitions = agents.map((agent, index) => {
     const skills = readColocatedAgentSkills(agent.handler)
@@ -82,7 +83,7 @@ function renderConsoleNitroPlugin(
             `const vitehubConsoleInvocations = installConsoleFixtureInvocations(${JSON.stringify(projectRoot)}, ${JSON.stringify(fixture)}, ${fixtureSource}, ${JSON.stringify(revision)}, ${JSON.stringify(runtimeBinding)})`,
             `installConsoleAgentDefinitions([${definitions}], { invocations: vitehubConsoleInvocations })`,
           ]
-        : [`installConsoleAgentDefinitions([${definitions}], { projectRoot: ${JSON.stringify(projectRoot)}${invoke ? ", invoke: true" : ""}${observations !== undefined ? `, observations: ${JSON.stringify(observations)}` : ""} })`]
+        : [`installConsoleAgentDefinitions([${definitions}], { projectRoot: ${JSON.stringify(projectRoot)}${invoke ? ", invoke: true" : ""}${observations !== undefined ? `, observations: ${JSON.stringify(observations)}` : ""}${databaseUrl !== undefined ? `, databaseUrl: ${JSON.stringify(databaseUrl)}` : ""} })`]
       : []),
     ...(kvEnabled
       ? [`installConsoleKV(${JSON.stringify(projectRoot)}, vitehubConsoleKV, ${JSON.stringify(kvStores)})`]
@@ -105,6 +106,7 @@ export async function writeConsoleNitroPlugin(
   invoke = false,
   observations: AgentInvocationsOptions["observations"] = undefined,
   active: () => boolean = () => true,
+  databaseUrl?: string,
 ): Promise<string> {
   const snapshot = fixture ? readConsoleFixture(fixture) : undefined
   const identity = createConsoleInvocationsIdentity(
@@ -114,7 +116,7 @@ export async function writeConsoleNitroPlugin(
     runtimeBinding,
   )
   if (!active()) return identity
-  const contents = renderConsoleNitroPlugin(projectRoot, sections, agents, catalog, blobStores, kvStores, fixture, snapshot, runtimeBinding, invoke, observations)
+  const contents = renderConsoleNitroPlugin(projectRoot, sections, agents, catalog, blobStores, kvStores, fixture, snapshot, runtimeBinding, invoke, observations, databaseUrl)
   if (await readFile(file, "utf8").catch(() => undefined) !== contents) {
     await mkdir(resolve(file, ".."), { recursive: true })
     await writeFile(file, contents, "utf8")

--- a/packages/vite-hub/src/console/runtime/server/agents.ts
+++ b/packages/vite-hub/src/console/runtime/server/agents.ts
@@ -17,7 +17,7 @@ export type ConsoleAgentDefinitionEntry = {
 
 export type ConsoleAgentDefinitionInstallation =
   | { invocations: AgentInvocations, projectRoot?: never }
-  | { invocations?: never, invoke?: boolean, observations?: AgentInvocationsOptions["observations"], projectRoot: string }
+  | { invocations?: never, invoke?: boolean, databaseUrl?: string, observations?: AgentInvocationsOptions["observations"], projectRoot: string }
 
 type ConsoleAgentInvocations = AgentInvocations & {
   [consoleAgentDefinitionsKey]?: ReadonlyMap<string, AgentInput>
@@ -80,7 +80,7 @@ function resolveConsoleAgentInvocations(
   if (configured.length > 1) {
     throw viteHubErrorDiagnostics.VITE_HUB_R0047({ message: "[vitehub] Console cannot inspect multiple Agent invocation journals. Configure one shared journal for the discovered Agent Definitions." })
   }
-  return installConsoleInvocations(installation.projectRoot, configured[0], installation.observations)
+  return installConsoleInvocations(installation.projectRoot, configured[0], installation.observations, installation.databaseUrl)
 }
 
 export function installConsoleAgents(

--- a/packages/vite-hub/src/console/runtime/server/invocations.ts
+++ b/packages/vite-hub/src/console/runtime/server/invocations.ts
@@ -92,6 +92,7 @@ export function getConsoleUsageIndex(invocations: AgentInvocations): ReturnType<
 }
 
 const consoleInvocationDatabases = new WeakMap<AgentInvocations, ConsoleInvocationsDatabase>()
+const consoleDatabaseConfigurations = new WeakMap<AgentInvocations, string>()
 const consoleObservationConfigurations = new WeakMap<AgentInvocations, string>()
 
 function observationConfiguration(observations: AgentInvocationsOptions["observations"]): string {
@@ -120,9 +121,9 @@ interface ConsoleDatabaseOptions {
   url: string
 }
 
-export function resolveConsoleDatabaseOptions(projectRoot: string): ConsoleDatabaseOptions {
+export function resolveConsoleDatabaseOptions(projectRoot: string, databaseUrl?: string): ConsoleDatabaseOptions {
   const configuredUrl = process.env.VITEHUB_CONSOLE_DATABASE_URL?.trim()
-  const url = configuredUrl || `file:${resolve(projectRoot, ".vitehub/data/console.sqlite")}`
+  const url = configuredUrl || databaseUrl || `file:${resolve(projectRoot, ".vitehub/data/console.sqlite")}`
   const authToken = process.env.VITEHUB_CONSOLE_DATABASE_AUTH_TOKEN
   if (!/^file:/i.test(url)) {
     const options: ConsoleDatabaseOptions = { url }
@@ -147,8 +148,9 @@ export function resolveConsoleDatabaseOptions(projectRoot: string): ConsoleDatab
   return { url: `${pathToFileURL(filePath).href}${query}` }
 }
 
-export function createConsoleInvocations(projectRoot: string, observations?: AgentInvocationsOptions["observations"]): AgentInvocations {
-  const client = createClient(resolveConsoleDatabaseOptions(projectRoot))
+export function createConsoleInvocations(projectRoot: string, observations?: AgentInvocationsOptions["observations"], databaseUrl?: string): AgentInvocations {
+  const database = resolveConsoleDatabaseOptions(projectRoot, databaseUrl)
+  const client = createClient(database)
   let invocations: AgentInvocations
   try {
     invocations = defineAgentInvocations({
@@ -166,6 +168,7 @@ export function createConsoleInvocations(projectRoot: string, observations?: Age
     client.close()
     throw error
   }
+  consoleDatabaseConfigurations.set(invocations, database.url)
   consoleObservationConfigurations.set(invocations, observationConfiguration(observations))
   consoleUsageIndexes.set(invocations, createConsoleUsageIndex(client))
   consoleInvocationDatabases.set(invocations, {
@@ -192,6 +195,7 @@ export function installConsoleInvocations(
   projectRoot: string,
   configuredInvocations?: AgentInvocations,
   observations?: AgentInvocationsOptions["observations"],
+  databaseUrl?: string,
 ): AgentInvocations {
   const resolvedRoot = resolve(projectRoot)
   const identity = createConsoleInvocationsIdentity(resolvedRoot)
@@ -200,8 +204,8 @@ export function installConsoleInvocations(
   const sameConfiguration = installedConfiguration === undefined
     ? observations === undefined
     : installedConfiguration === observationConfiguration(observations)
-  if (installed && resolveConsoleInvocationsIdentity() === identity && (configuredInvocations ? installed === configuredInvocations : sameConfiguration)) return installed
-  const invocations = configuredInvocations ?? createConsoleInvocations(resolvedRoot, observations)
+  if (installed && resolveConsoleInvocationsIdentity() === identity && (configuredInvocations ? installed === configuredInvocations : sameConfiguration && consoleDatabaseConfigurations.get(installed) === resolveConsoleDatabaseOptions(resolvedRoot, databaseUrl).url)) return installed
+  const invocations = configuredInvocations ?? createConsoleInvocations(resolvedRoot, observations, databaseUrl)
   installConsoleInvocationFallback(invocations, resolvedRoot, globalThis, identity)
   return invocations
 }

--- a/packages/vite-hub/src/console/vite.ts
+++ b/packages/vite-hub/src/console/vite.ts
@@ -61,6 +61,7 @@ export type ConsoleOptions = (
 interface ConsoleVitePluginOptions {
   blobStores?: readonly string[]
   console?: true | ConsoleOptions
+  databaseUrl?: string
   databaseDiscoveryRoot?: string
   kvStores?: readonly string[]
   preset?: string
@@ -298,7 +299,7 @@ export function consoleVitePlugin(options: ConsoleVitePluginOptions = {}): Plugi
         fixture = resolve(projectRoot, configuredFixture)
         readConsoleFixture(fixture)
       }
-      databaseUrl = configured === true ? undefined : configured.databaseUrl
+      databaseUrl = (configured === true ? undefined : configured.databaseUrl) ?? options.databaseUrl
       observations = configured === true ? undefined : configured.observations
       invoke = !fixture && (configured === true || configured.invoke === true)
       generatedPlugin = resolveGeneratedConsolePlugin(root, fixture, options.invocationRootState)

--- a/packages/vite-hub/src/console/vite.ts
+++ b/packages/vite-hub/src/console/vite.ts
@@ -56,7 +56,7 @@ type ConsoleNitroConfig = {
 export type ConsoleOptions = (
   | { access: "auth", exposure?: never, invoke?: boolean }
   | { access?: never, exposure: "host-managed", invoke?: boolean }
-) & { observations?: AgentInvocationsOptions["observations"] }
+) & { databaseUrl?: string, observations?: AgentInvocationsOptions["observations"] }
 
 interface ConsoleVitePluginOptions {
   blobStores?: readonly string[]
@@ -192,12 +192,13 @@ export function consoleVitePlugin(options: ConsoleVitePluginOptions = {}): Plugi
   let fixture: string | undefined
   let cliDiscovery = false
   let invoke = false
+  let databaseUrl: string | undefined
   let observations: AgentInvocationsOptions["observations"]
 
   const refreshConsoleCatalog = serializeConsoleRefresh(async () => {
     if (!generatedPlugin || !projectRoot || !root) return
     const catalog = await discoverConsoleBuildCatalog({ databaseDiscoveryRoot, discoveryRoot: root, projectRoot, rateLimitDiscoveryRoot, rateLimitScanDirs, sandboxDiscoveryRoot: root, scheduleDiscoveryRoot, sections, serverDirs, workspaceDiscoveryRoot })
-    const identity = await writeConsoleNitroPlugin(generatedPlugin, projectRoot, sections, catalog.agents, catalog, blobStores, kvStores, fixture, options.invocationRootState?.binding, invoke, observations, () => !options.invocationRootState?.closed)
+    const identity = await writeConsoleNitroPlugin(generatedPlugin, projectRoot, sections, catalog.agents, catalog, blobStores, kvStores, fixture, options.invocationRootState?.binding, invoke, observations, () => !options.invocationRootState?.closed, databaseUrl)
     if (options.invocationRootState) updateConsoleInvocationRootState(options.invocationRootState, projectRoot, identity)
   })
 
@@ -297,6 +298,7 @@ export function consoleVitePlugin(options: ConsoleVitePluginOptions = {}): Plugi
         fixture = resolve(projectRoot, configuredFixture)
         readConsoleFixture(fixture)
       }
+      databaseUrl = configured === true ? undefined : configured.databaseUrl
       observations = configured === true ? undefined : configured.observations
       invoke = !fixture && (configured === true || configured.invoke === true)
       generatedPlugin = resolveGeneratedConsolePlugin(root, fixture, options.invocationRootState)
@@ -319,6 +321,8 @@ export function consoleVitePlugin(options: ConsoleVitePluginOptions = {}): Plugi
           options.invocationRootState?.binding,
           invoke,
           observations,
+          undefined,
+          databaseUrl,
         )
       }
       // SAFETY: Nitro extends Vite's user config with this documented top-level configuration object.

--- a/packages/vite-hub/src/error-diagnostics.ts
+++ b/packages/vite-hub/src/error-diagnostics.ts
@@ -8,6 +8,8 @@ const dynamicError = {
 export const viteHubErrorDiagnostics = /*#__PURE__*/ defineDiagnostics({
   docsBase: () => "https://vitehub.dev/docs/reference/errors-diagnostics",
   codes: {
+    VITE_HUB_R0120: dynamicError,
+    VITE_HUB_R0121: dynamicError,
     VITE_HUB_R0116: dynamicError,
     VITE_HUB_R0117: dynamicError,
     VITE_HUB_R0118: dynamicError,

--- a/packages/vite-hub/src/index.ts
+++ b/packages/vite-hub/src/index.ts
@@ -1,4 +1,4 @@
-import { withDataDir } from "./storage-config.ts"
+import { consoleDatabaseUrl, withDataDir } from "./storage-config.ts"
 import { existsSync, readFileSync } from "node:fs"
 import { basename, dirname, join, relative, resolve } from "node:path"
 import { fileURLToPath } from "node:url"
@@ -768,6 +768,7 @@ export function vitehub(options: ViteHubOptions): PluginOption[] {
     plugins.push(consoleVitePlugin({
       blobStores: consoleBlobStores,
       console: options.console === true ? true : options.console,
+      databaseUrl: consoleDatabaseUrl(options),
       databaseDiscoveryRoot: options.database && options.database !== true ? options.database.projectRoot : undefined,
       kvStores: presetKV ? Object.keys(presetKV.stores || { default: presetKV.store }) : [],
       preset: plan.preset,

--- a/packages/vite-hub/src/index.ts
+++ b/packages/vite-hub/src/index.ts
@@ -1,3 +1,4 @@
+import { withDataDir } from "./storage-config.ts"
 import { existsSync, readFileSync } from "node:fs"
 import { basename, dirname, join, relative, resolve } from "node:path"
 import { fileURLToPath } from "node:url"
@@ -243,6 +244,8 @@ function frameworkDependencyResolver(
 }
 
 export interface ViteHubOptions {
+  /** Local storage defaults for a Node host with a persistent filesystem. Relative to the working directory. */
+  dataDir?: string
   preset: DeploymentPreset
   name?: string
   agent?: boolean | AgentModuleOptions
@@ -703,6 +706,7 @@ function presetBlobOptions(
 
 export function vitehub(options: ViteHubOptions): PluginOption[] {
   if (!options || typeof options !== "object") throw viteHubErrorDiagnostics.VITE_HUB_R0085({ message: "vitehub() requires a built-in deployment preset." })
+  options = withDataDir(options)
   const plan = resolveDeploymentPlan(options.preset)
   if (options.schedule && plan.preset === "deno") {
     throw viteHubErrorDiagnostics.VITE_HUB_R0086({ message: "[vitehub] The \"deno\" preset cannot provide Schedule because its generated cron output is not part of the deployed Nitro entrypoint. Disable Schedule or compose an explicit Deno scheduling integration." })

--- a/packages/vite-hub/src/nuxt.ts
+++ b/packages/vite-hub/src/nuxt.ts
@@ -1,4 +1,4 @@
-import { withDataDir } from "./storage-config.ts"
+import { consoleDatabaseUrl, withDataDir } from "./storage-config.ts"
 import { join, relative, resolve } from "node:path"
 import { fileURLToPath } from "node:url"
 
@@ -1167,7 +1167,7 @@ const viteHubNuxtModule: ViteHubNuxtModule = async function viteHubNuxtModule(in
         consoleInvokeEnabled && !resolvedConsoleFixture,
         options.console === true ? undefined : options.console.observations,
         () => !consoleInvocationRootState.closed,
-        options.console === true ? undefined : options.console.databaseUrl,
+        consoleDatabaseUrl(options),
       )
     }
     Object.assign(config, mergeGeneratedSourceNitroConfig(config, generatedSourceHandlers))
@@ -1241,7 +1241,7 @@ const viteHubNuxtModule: ViteHubNuxtModule = async function viteHubNuxtModule(in
         scheduleDiscoveryRoot: configuredProjectRoot(viteRoot, options.schedule),
         workspaceDiscoveryRoot: configuredProjectRoot(viteRoot, nuxt.options.vite.workspace ?? options.workspace),
       },
-      options.console === true ? undefined : options.console.databaseUrl,
+      consoleDatabaseUrl(options),
     )
   }
 }

--- a/packages/vite-hub/src/nuxt.ts
+++ b/packages/vite-hub/src/nuxt.ts
@@ -1,3 +1,4 @@
+import { withDataDir } from "./storage-config.ts"
 import { join, relative, resolve } from "node:path"
 import { fileURLToPath } from "node:url"
 
@@ -315,6 +316,7 @@ async function installConsole(
   invocationRootState?: ConsoleInvocationRootState,
   canDiscoverDefinitions: () => boolean = () => true,
   discoveryOptions: Pick<Parameters<typeof discoverConsoleBuildCatalog>[0], "databaseDiscoveryRoot" | "rateLimitDiscoveryRoot" | "rateLimitScanDirs" | "scheduleDiscoveryRoot" | "workspaceDiscoveryRoot"> = {},
+  databaseUrl?: string,
 ): Promise<string> {
   const uiModule = (await import("@vite-hub/ui/nuxt")).default
   const uiConfigured = (nuxt.options.modules ?? []).some((entry) => {
@@ -327,7 +329,7 @@ async function installConsole(
   const plugin = resolveGeneratedConsolePlugin(projectRoot, fixture, invocationRootState)
   installConsoleSections(projectRoot, sections)
   installConsoleProjectName(projectRoot, resolveConsoleProjectNameFromRoot(projectRoot))
-  if (installInvocations && nuxt.options.dev && sections.includes("agents") && !fixture) installConsoleInvocations(projectRoot, undefined, observations)
+  if (installInvocations && nuxt.options.dev && sections.includes("agents") && !fixture) installConsoleInvocations(projectRoot, undefined, observations, databaseUrl)
   const routeRules = (nuxt.options.routeRules ??= {})
   for (const route of ["/_vitehub", "/_vitehub/**"]) {
     const rule = (routeRules[route] ??= {})
@@ -473,6 +475,7 @@ async function installConsole(
       invoke,
       observations,
       () => !invocationRootState?.closed,
+      databaseUrl,
     )
     if (invocationRootState) {
       updateConsoleInvocationRootState(invocationRootState, projectRoot, identity)
@@ -787,10 +790,10 @@ const viteHubNuxtModule: ViteHubNuxtModule = async function viteHubNuxtModule(in
   const envOptions = configuredEnv && typeof configuredEnv === "object"
     ? Object.fromEntries(Object.entries(configuredEnv).filter(([key]) => !["define", "public", "server"].includes(key)))
     : configuredEnv
-  const options = {
+  const options = withDataDir({
     ...moduleOptions,
     env: envOptions,
-  } as Parameters<typeof vitehub>[0]
+  } as Parameters<typeof vitehub>[0])
   const plan = resolveDeploymentPlan(options.preset)
   const nitro = (nuxt.options.nitro ??= {})
   const nitroPreset = plan.preset === "cloudflare" && options.realtime
@@ -1164,6 +1167,7 @@ const viteHubNuxtModule: ViteHubNuxtModule = async function viteHubNuxtModule(in
         consoleInvokeEnabled && !resolvedConsoleFixture,
         options.console === true ? undefined : options.console.observations,
         () => !consoleInvocationRootState.closed,
+        options.console === true ? undefined : options.console.databaseUrl,
       )
     }
     Object.assign(config, mergeGeneratedSourceNitroConfig(config, generatedSourceHandlers))
@@ -1237,6 +1241,7 @@ const viteHubNuxtModule: ViteHubNuxtModule = async function viteHubNuxtModule(in
         scheduleDiscoveryRoot: configuredProjectRoot(viteRoot, options.schedule),
         workspaceDiscoveryRoot: configuredProjectRoot(viteRoot, nuxt.options.vite.workspace ?? options.workspace),
       },
+      options.console === true ? undefined : options.console.databaseUrl,
     )
   }
 }

--- a/packages/vite-hub/src/storage-config.ts
+++ b/packages/vite-hub/src/storage-config.ts
@@ -34,13 +34,20 @@ export function withDataDir(options: ViteHubOptions): ViteHubOptions {
     ...(agent && state !== false && (!state?.provider || ["auto", "sqlite", "libsql"].includes(state.provider)) ? {
       agent: { ...agent, providers: { ...agent.providers, state: { ...state, provider: state?.provider ?? "libsql", url: state?.url ?? file("agent-state.sqlite") } } },
     } : {}),
-    ...(options.console ? { console: {
-      ...(options.console === true ? { access: "auth" as const } : options.console),
-      databaseUrl: (options.console === true ? undefined : options.console.databaseUrl) ?? file("console.sqlite"),
+    ...(options.console && options.console !== true ? { console: {
+      ...options.console,
+      databaseUrl: options.console.databaseUrl ?? file("console.sqlite"),
     } } : {}),
     ...(options.workspace ? { workspace: {
       ...(options.workspace === true ? {} : options.workspace),
       root: (options.workspace === true ? undefined : options.workspace.root) ?? join(root, "workspaces"),
     } } : {}),
   }
+}
+
+/** Resolve the journal path without changing the development-only Console shorthand. */
+export function consoleDatabaseUrl(options: ViteHubOptions): string | undefined {
+  if (!options.console) return undefined
+  return (options.console === true ? undefined : options.console.databaseUrl)
+    ?? (options.dataDir ? pathToFileURL(resolve(options.dataDir, "console.sqlite")).href : undefined)
 }

--- a/packages/vite-hub/src/storage-config.ts
+++ b/packages/vite-hub/src/storage-config.ts
@@ -3,12 +3,13 @@ import { pathToFileURL } from "node:url"
 import type { BlobStoreConfig } from "@vite-hub/blob"
 import type { KVStoreConfig } from "@vite-hub/kv"
 import type { ViteHubOptions } from "./index.ts"
+import { viteHubErrorDiagnostics } from "./error-diagnostics.ts"
 
 /** An explicit Node data directory selects local storage; the host owns durability. */
 export function withDataDir(options: ViteHubOptions): ViteHubOptions {
   if (options.dataDir === undefined) return options
-  if (options.preset !== "node") throw new TypeError("[vitehub] dataDir requires the node preset and a persistent filesystem. Configure remote stores for other hosts.")
-  if (!options.dataDir.trim()) throw new TypeError("[vitehub] dataDir must be a non-empty directory path.")
+  if (options.preset !== "node") throw viteHubErrorDiagnostics.VITE_HUB_R0120({ message: "[vitehub] dataDir requires the node preset and a persistent filesystem. Configure remote stores for other hosts." })
+  if (!options.dataDir.trim()) throw viteHubErrorDiagnostics.VITE_HUB_R0121({ message: "[vitehub] dataDir must be a non-empty directory path." })
   const root = resolve(options.dataDir)
   const file = (name: string) => pathToFileURL(join(root, name)).href
   const kvStore = (store: KVStoreConfig, name?: string): KVStoreConfig => store.driver === "fs-lite"

--- a/packages/vite-hub/src/storage-config.ts
+++ b/packages/vite-hub/src/storage-config.ts
@@ -1,0 +1,45 @@
+import { join, resolve } from "node:path"
+import { pathToFileURL } from "node:url"
+import type { BlobStoreConfig } from "@vite-hub/blob"
+import type { KVStoreConfig } from "@vite-hub/kv"
+import type { ViteHubOptions } from "./index.ts"
+
+/** An explicit Node data directory selects local storage; the host owns durability. */
+export function withDataDir(options: ViteHubOptions): ViteHubOptions {
+  if (options.dataDir === undefined) return options
+  if (options.preset !== "node") throw new TypeError("[vitehub] dataDir requires the node preset and a persistent filesystem. Configure remote stores for other hosts.")
+  if (!options.dataDir.trim()) throw new TypeError("[vitehub] dataDir must be a non-empty directory path.")
+  const root = resolve(options.dataDir)
+  const file = (name: string) => pathToFileURL(join(root, name)).href
+  const kvStore = (store: KVStoreConfig, name?: string): KVStoreConfig => store.driver === "fs-lite"
+    ? { ...store, base: store.base ?? join(root, "kv", ...(name ? [name] : [])) }
+    : store
+  const blobStore = (store: BlobStoreConfig, name?: string): BlobStoreConfig => store.driver === "fs"
+    ? { ...store, base: store.base ?? join(root, "blob", ...(name ? [name] : [])) }
+    : store
+  const kv = options.kv === true ? { driver: "fs-lite" as const } : options.kv
+  const blob = options.blob === true ? { driver: "fs" as const } : options.blob
+  const agent = options.agent === true ? {} : options.agent
+  const state = agent && agent.providers?.state
+  return {
+    ...options,
+    dataDir: root,
+    ...(kv ? { kv: "stores" in kv
+      ? { ...kv, stores: Object.fromEntries(Object.entries(kv.stores).map(([name, store]) => [name, kvStore(store, name)])) }
+      : kvStore(kv) } : {}),
+    ...(blob ? { blob: "stores" in blob
+      ? { ...blob, stores: Object.fromEntries(Object.entries(blob.stores).map(([name, store]) => [name, blobStore(store, name)])) }
+      : !blob.driver || blob.driver === "fs" ? { ...blob, driver: "fs" as const, base: "base" in blob ? blob.base ?? join(root, "blob") : join(root, "blob") } : blob } : {}),
+    ...(agent && state !== false && (!state?.provider || ["auto", "sqlite", "libsql"].includes(state.provider)) ? {
+      agent: { ...agent, providers: { ...agent.providers, state: { ...state, provider: state?.provider ?? "libsql", url: state?.url ?? file("agent-state.sqlite") } } },
+    } : {}),
+    ...(options.console ? { console: {
+      ...(options.console === true ? { access: "auth" as const } : options.console),
+      databaseUrl: (options.console === true ? undefined : options.console.databaseUrl) ?? file("console.sqlite"),
+    } } : {}),
+    ...(options.workspace ? { workspace: {
+      ...(options.workspace === true ? {} : options.workspace),
+      root: (options.workspace === true ? undefined : options.workspace.root) ?? join(root, "workspaces"),
+    } } : {}),
+  }
+}

--- a/packages/vite-hub/test/console.test.ts
+++ b/packages/vite-hub/test/console.test.ts
@@ -3926,6 +3926,35 @@ describe("Agent invocation console", () => {
     }
   })
 
+  it("persists configured Console storage across instances and isolates another URL", async () => {
+    const projectRoot = await mkdtemp(join(tmpdir(), "vitehub-console-configured-"))
+    const databaseUrl = pathToFileURL(join(projectRoot, "persistent", "history.sqlite")).href
+    const otherUrl = pathToFileURL(join(projectRoot, "persistent", "other.sqlite")).href
+    try {
+      const writer = installConsoleInvocations(projectRoot, undefined, undefined, databaseUrl)
+      expect(installConsoleInvocations(projectRoot, undefined, undefined, databaseUrl)).toBe(writer)
+      const agent = defineAgent({ driver: { run: () => "stored at configured path" }, runtime: false })
+      await runAgent(agent, runtime("configured-console-storage"), {})
+      const readers = [createConsoleInvocations(projectRoot, undefined, databaseUrl), createConsoleInvocations(projectRoot, undefined, databaseUrl)]
+      for (const reader of readers) {
+        await expect(reader.getByRunId("configured-console-storage")).resolves.toMatchObject({ status: "completed" })
+      }
+      const other = installConsoleInvocations(projectRoot, undefined, undefined, otherUrl)
+      expect(other).not.toBe(writer)
+      await expect(other.getByRunId("configured-console-storage")).resolves.toBeUndefined()
+      expect(existsSync(join(projectRoot, "persistent", "history.sqlite"))).toBe(true)
+      expect(existsSync(join(projectRoot, ".vitehub", "data", "console.sqlite"))).toBe(false)
+    }
+    finally {
+      await rm(projectRoot, { force: true, recursive: true })
+    }
+  })
+
+  it("allows a runtime URL to override the Console config", () => {
+    vi.stubEnv("VITEHUB_CONSOLE_DATABASE_URL", "libsql://runtime.example.com")
+    expect(resolveConsoleDatabaseOptions(process.cwd(), "libsql://configured.example.com")).toEqual({ url: "libsql://runtime.example.com" })
+  })
+
   it("anchors the durable journal to the project root and shares it between runtime instances", async () => {
     const projectRoot = await mkdtemp(join(tmpdir(), "vitehub-console-project-"))
     const unrelatedCwd = await mkdtemp(join(tmpdir(), "vitehub-console-cwd-"))

--- a/packages/vite-hub/test/nuxt.test.ts
+++ b/packages/vite-hub/test/nuxt.test.ts
@@ -603,6 +603,21 @@ describe("ViteHub Nuxt integration", () => {
     )
   })
 
+  it.each([true, false])("carries the Node data directory into the Nuxt Console bootstrap (dev: %s)", async (dev) => {
+    const application = createNuxt(dev)
+    await viteHubNuxtModule({
+      preset: "node",
+      dataDir: "/tmp/vitehub-nuxt/persistent data",
+      agent: true,
+      console: { exposure: "host-managed" },
+    }, application.nuxt)
+
+    await expect(readFile("/tmp/vitehub-nuxt/.vitehub/nitro/console/plugin.mjs", "utf8")).resolves.toContain(
+      'databaseUrl: "file:///tmp/vitehub-nuxt/persistent%20data/console.sqlite"',
+    )
+    await application.runCloseHook()
+  })
+
   it("installs only KV navigation and metadata for a KV-only Console", async () => {
     const development = createNuxt(true)
 

--- a/packages/vite-hub/test/nuxt.test.ts
+++ b/packages/vite-hub/test/nuxt.test.ts
@@ -618,6 +618,20 @@ describe("ViteHub Nuxt integration", () => {
     await application.runCloseHook()
   })
 
+  it("preserves Console shorthand invocation with a Node data directory", async () => {
+    const application = createNuxt(true)
+    await viteHubNuxtModule({
+      preset: "node",
+      dataDir: "/tmp/vitehub-nuxt/persistent data",
+      agent: true,
+      console: true,
+    }, application.nuxt)
+    const generated = await readFile("/tmp/vitehub-nuxt/.vitehub/nitro/console/plugin.mjs", "utf8")
+    expect(generated).toContain("invoke: true")
+    expect(generated).toContain('databaseUrl: "file:///tmp/vitehub-nuxt/persistent%20data/console.sqlite"')
+    await application.runCloseHook()
+  })
+
   it("installs only KV navigation and metadata for a KV-only Console", async () => {
     const development = createNuxt(true)
 
@@ -1589,10 +1603,10 @@ describe("ViteHub Nuxt integration", () => {
     expect(generated).toContain(`observations: ${JSON.stringify(observations)}`)
   })
 
-  it("rejects bare production Console enablement", async () => {
+  it.each([undefined, "/tmp/vitehub-nuxt/persistent data"])("rejects bare production Console enablement with dataDir %s", async (dataDir) => {
     const production = createNuxt(false)
 
-    await expect(viteHubNuxtModule({ console: true, preset: "node" }, production.nuxt))
+    await expect(viteHubNuxtModule({ console: true, preset: "node", dataDir }, production.nuxt))
       .rejects.toThrow("console: true is development-only")
   })
 

--- a/packages/vite-hub/test/storage-defaults.test.ts
+++ b/packages/vite-hub/test/storage-defaults.test.ts
@@ -1,5 +1,8 @@
+import { mkdtemp, readFile, rm } from "node:fs/promises"
+import { tmpdir } from "node:os"
 import { join } from "node:path"
 import { pathToFileURL } from "node:url"
+import type { Plugin } from "vite"
 import { describe, expect, it } from "vitest"
 import { withDataDir } from "../src/storage-config.ts"
 import { vitehub } from "../src/index.ts"
@@ -9,11 +12,36 @@ describe("Node storage defaults", () => {
     const dataDir = "/var/lib/app data"
     expect(withDataDir({ preset: "node", dataDir, agent: true, console: true, kv: true, blob: true, workspace: true })).toMatchObject({
       agent: { providers: { state: { provider: "libsql", url: pathToFileURL(join(dataDir, "agent-state.sqlite")).href } } },
-      console: { databaseUrl: pathToFileURL(join(dataDir, "console.sqlite")).href },
+      console: true,
       kv: { driver: "fs-lite", base: join(dataDir, "kv") },
       blob: { driver: "fs", base: join(dataDir, "blob") },
       workspace: { root: join(dataDir, "workspaces") },
     })
+  })
+
+  it.each(["serve", "build"] as const)("preserves Vite Console shorthand with dataDir during %s", async (command) => {
+    const root = await mkdtemp(join(tmpdir(), "vitehub-storage-console-"))
+    try {
+      const dataDir = join(root, "persistent data")
+      const plugin = vitehub({ preset: "node", dataDir, agent: true, console: true })
+        .find((plugin): plugin is Plugin => !!plugin && typeof plugin === "object" && "name" in plugin && plugin.name === "vite-hub/console")
+      const hook = plugin?.config
+      if (!hook) throw new TypeError("Expected a Console config hook.")
+      const handler = "handler" in hook ? hook.handler : hook
+      const configure = Reflect.apply(handler, {}, [{ root }, { command, mode: command === "build" ? "production" : "development" }])
+      if (command === "build") {
+        await expect(configure).rejects.toThrow("console: true is development-only")
+      }
+      else {
+        await configure
+        const generated = await readFile(join(root, ".vitehub/nitro/console/plugin.mjs"), "utf8")
+        expect(generated).toContain("invoke: true")
+        expect(generated).toContain(`databaseUrl: ${JSON.stringify(pathToFileURL(join(dataDir, "console.sqlite")).href)}`)
+      }
+    }
+    finally {
+      await rm(root, { force: true, recursive: true })
+    }
   })
 
   it("preserves explicit storage and disabled Agents", () => {

--- a/packages/vite-hub/test/storage-defaults.test.ts
+++ b/packages/vite-hub/test/storage-defaults.test.ts
@@ -1,0 +1,54 @@
+import { join } from "node:path"
+import { pathToFileURL } from "node:url"
+import { describe, expect, it } from "vitest"
+import { withDataDir } from "../src/storage-config.ts"
+import { vitehub } from "../src/index.ts"
+
+describe("Node storage defaults", () => {
+  it("puts enabled local stores under the explicit directory", () => {
+    const dataDir = "/var/lib/app data"
+    expect(withDataDir({ preset: "node", dataDir, agent: true, console: true, kv: true, blob: true, workspace: true })).toMatchObject({
+      agent: { providers: { state: { provider: "libsql", url: pathToFileURL(join(dataDir, "agent-state.sqlite")).href } } },
+      console: { databaseUrl: pathToFileURL(join(dataDir, "console.sqlite")).href },
+      kv: { driver: "fs-lite", base: join(dataDir, "kv") },
+      blob: { driver: "fs", base: join(dataDir, "blob") },
+      workspace: { root: join(dataDir, "workspaces") },
+    })
+  })
+
+  it("preserves explicit storage and disabled Agents", () => {
+    const options = {
+      preset: "node" as const,
+      dataDir: "/var/lib/app",
+      agent: false as const,
+      console: { exposure: "host-managed" as const, databaseUrl: "libsql://journal.example.com" },
+      kv: { driver: "upstash" as const, url: "https://kv.example.com", token: "fixture" },
+      blob: { driver: "fs" as const, base: "/existing/uploads" },
+      workspace: { root: "/existing/workspaces" },
+    }
+    expect(withDataDir(options)).toEqual(options)
+  })
+
+  it("keeps remote agent state and does not enable disabled services", () => {
+    const options = { preset: "node" as const, dataDir: "/var/lib/app", agent: { providers: { state: { provider: "libsql" as const, url: "libsql://state.example.com" } } }, kv: false as const, blob: false as const }
+    expect(withDataDir(options)).toEqual(options)
+  })
+
+  it("gives named local stores separate directories and preserves remote stores", () => {
+    const result = withDataDir({ preset: "node", dataDir: "/var/lib/app", kv: { stores: { first: { driver: "fs-lite" }, second: { driver: "fs-lite" } } }, blob: { stores: { uploads: { driver: "fs" }, external: { driver: "vercel-blob", token: "fixture" } } } })
+    expect(result.kv).toEqual({ stores: { first: { driver: "fs-lite", base: "/var/lib/app/kv/first" }, second: { driver: "fs-lite", base: "/var/lib/app/kv/second" } } })
+    expect(result.blob).toEqual({ stores: { uploads: { driver: "fs", base: "/var/lib/app/blob/uploads" }, external: { driver: "vercel-blob", token: "fixture" } } })
+  })
+
+  it("rejects local storage on hosted ephemeral presets through the public API", () => {
+    for (const preset of ["cloudflare", "vercel", "netlify", "deno"] as const) {
+      expect(() => vitehub({ preset, dataDir: "/data" })).toThrow("dataDir requires the node preset")
+    }
+    expect(() => vitehub({ preset: "node", dataDir: "  " })).toThrow("non-empty")
+  })
+
+  it("keeps existing defaults when no directory is supplied", () => {
+    const options = { preset: "node" as const, agent: true }
+    expect(withDataDir(options)).toBe(options)
+  })
+})


### PR DESCRIPTION
Node applications with persistent storage currently configure separate paths for Agent State, Console, KV, Blob, and Workspaces. Add `dataDir` to derive those paths once, preserving explicit paths, remote providers, and disabled services.

Console also accepts `databaseUrl`, carried through Vite and Nuxt server output, so applications can preserve existing journals without environment overrides. The host still owns the persistent filesystem; changing `dataDir` does not migrate data.

Regression coverage checks path precedence, named-store isolation, host restrictions, Nuxt bootstrap output, and Console journal persistence across runtime instances.

Model: GPT-6 Astra. Harness: Codex.
