### PR TITLE
fix(agent): point diagnostics to existing docs anchor

### DIFF
--- a/packages/agent/src/agent-diagnostics.ts
+++ b/packages/agent/src/agent-diagnostics.ts
@@ -453,7 +453,7 @@ const dynamicError = {
 
 // Throw-only diagnostics. The CLI and model adapters choose how to report them.
 export const agentDiagnostics = defineDiagnostics({
-  docsBase: () => "https://vitehub.dev/docs/reference/errors-diagnostics#agent-diagnostics",
+  docsBase: () => "https://vitehub.dev/docs/reference/errors-diagnostics#agent-public-errors",
   codes: {
     AGENT_R0907: dynamicError,
     AGENT_R0908: dynamicError,

--- a/packages/agent/src/agent-diagnostics.ts
+++ b/packages/agent/src/agent-diagnostics.ts
@@ -453,7 +453,7 @@ const dynamicError = {
 
 // Throw-only diagnostics. The CLI and model adapters choose how to report them.
 export const agentDiagnostics = defineDiagnostics({
-  docsBase: () => "https://vitehub.dev/docs/reference/diagnostics#agent-public-errors",
+  docsBase: () => "https://vitehub.dev/docs/reference/errors-diagnostics#agent-public-errors",
   codes: {
     AGENT_R0907: dynamicError,
     AGENT_R0908: dynamicError,

--- a/packages/agent/src/http-error.ts
+++ b/packages/agent/src/http-error.ts
@@ -13,7 +13,7 @@ export class AgentHttpError extends Diagnostic {
   readonly statusCode: number
 
   constructor(statusCode: number, message: string) {
-    super({ code: "AGENT_R0891", docs: "https://vitehub.dev/docs/reference/diagnostics#agent-public-errors", why: message }, AgentHttpError)
+    super({ code: "AGENT_R0891", docs: "https://vitehub.dev/docs/reference/errors-diagnostics#agent-public-errors", why: message }, AgentHttpError)
     this.name = "AgentHttpError"
     this.status = statusCode
     this.statusCode = statusCode

--- a/packages/agent/src/http-error.ts
+++ b/packages/agent/src/http-error.ts
@@ -13,7 +13,7 @@ export class AgentHttpError extends Diagnostic {
   readonly statusCode: number
 
   constructor(statusCode: number, message: string) {
-    super({ code: "AGENT_R0891", docs: "https://vitehub.dev/docs/reference/errors-diagnostics#agent-diagnostics", why: message }, AgentHttpError)
+    super({ code: "AGENT_R0891", docs: "https://vitehub.dev/docs/reference/errors-diagnostics#agent-public-errors", why: message }, AgentHttpError)
     this.name = "AgentHttpError"
     this.status = statusCode
     this.statusCode = statusCode

--- a/packages/agent/src/index.ts
+++ b/packages/agent/src/index.ts
@@ -3239,7 +3239,7 @@ class AgentTelemetryCapabilityError extends Diagnostic {
     super({
       cause,
       code: "AGENT_R0890",
-      docs: "https://vitehub.dev/docs/reference/diagnostics#agent-public-errors",
+      docs: "https://vitehub.dev/docs/reference/errors-diagnostics#agent-public-errors",
       why: `[vitehub] Capability "${capabilityId}" telemetry export failed.`,
     }, AgentTelemetryCapabilityError)
     this.name = "AgentTelemetryCapabilityError"

--- a/packages/agent/src/index.ts
+++ b/packages/agent/src/index.ts
@@ -3239,7 +3239,7 @@ class AgentTelemetryCapabilityError extends Diagnostic {
     super({
       cause,
       code: "AGENT_R0890",
-      docs: "https://vitehub.dev/docs/reference/errors-diagnostics#agent-diagnostics",
+      docs: "https://vitehub.dev/docs/reference/errors-diagnostics#agent-public-errors",
       why: `[vitehub] Capability "${capabilityId}" telemetry export failed.`,
     }, AgentTelemetryCapabilityError)
     this.name = "AgentTelemetryCapabilityError"

--- a/packages/agent/src/server/github-host.ts
+++ b/packages/agent/src/server/github-host.ts
@@ -109,7 +109,7 @@ class GitHubRateLimitError extends Diagnostic {
     super({
       cause,
       code: "AGENT_R0889",
-      docs: "https://vitehub.dev/docs/reference/diagnostics#agent-public-errors",
+      docs: "https://vitehub.dev/docs/reference/errors-diagnostics#agent-public-errors",
       why: `GitHub GraphQL work for ${repository} is queued until ${new Date(limit.resetAt).toISOString()} (${limit.remaining} points remaining).`,
     }, GitHubRateLimitError)
     this.name = "GitHubRateLimitError"

--- a/packages/agent/src/server/github-host.ts
+++ b/packages/agent/src/server/github-host.ts
@@ -109,7 +109,7 @@ class GitHubRateLimitError extends Diagnostic {
     super({
       cause,
       code: "AGENT_R0889",
-      docs: "https://vitehub.dev/docs/reference/errors-diagnostics#agent-diagnostics",
+      docs: "https://vitehub.dev/docs/reference/errors-diagnostics#agent-public-errors",
       why: `GitHub GraphQL work for ${repository} is queued until ${new Date(limit.resetAt).toISOString()} (${limit.remaining} points remaining).`,
     }, GitHubRateLimitError)
     this.name = "GitHubRateLimitError"


### PR DESCRIPTION
Provider errors emitted links to `#agent-diagnostics`, but the published errors reference has no heading with that fragment. Users following diagnostics such as `AGENT_R0726` therefore land at the top of the page instead of the relevant Agent error guidance.

Update the shared Agent diagnostics URL and the three explicit Agent-owned error URLs to `#agent-public-errors`, which exists in the published reference. Audit of all other package documentation fragments found no additional unresolved anchors.

Validation: focused Agent diagnostics tests were attempted but cannot start in this checkout because the `vitest` package is unavailable (`ERR_MODULE_NOT_FOUND`).

Model: GPT-6. Harness: Codex.

