### PR TITLE
docs: add dedicated diagnostics reference

### DIFF
--- a/docs/content/docs/reference/diagnostics.md
+++ b/docs/content/docs/reference/diagnostics.md
@@ -1,0 +1,25 @@
+---
+title: Diagnostics
+description: Find ViteHub diagnostic codes, repair guidance, and verification steps.
+navigation.order: 1
+navigation.group: Diagnostics
+icon: i-lucide-circle-alert
+---
+
+ViteHub diagnostics identify configuration, build, and runtime defects with stable codes. When an error includes a documentation link, it points to this reference so you can find the owning package and the next proof step.
+
+## Agent diagnostics
+
+Agent errors use `AGENT_C####`, `AGENT_B####`, and `AGENT_R####` codes. Agent routes and hooks expose a sanitized public error that is safe to serialize. Keep the original error in protected server diagnostics because provider payloads and causes can contain credentials or private response data.
+
+Use the complete diagnostic code when classifying an error. The error's `fix` text gives the immediate repair action, while the source and provider details identify what to verify.
+
+## Other package diagnostics
+
+Each ViteHub package owns its diagnostic catalog. The package prefix identifies the owner, and the family letter identifies configuration, build, or general runtime defects. See [Errors and diagnostics](/docs/reference/errors-diagnostics) for the shared error contract, serialization rules, and operational error behavior.
+
+## Verify a diagnostic
+
+1. Read the complete `code` and `fix` fields.
+2. Inspect the provider output, source locations, or trace events named by the diagnostic.
+3. Re-run the nearest package or consumer test after applying the repair.

--- a/docs/content/docs/reference/errors-diagnostics.md
+++ b/docs/content/docs/reference/errors-diagnostics.md
@@ -1,8 +1,8 @@
 ---
 title: Errors and diagnostics
 description: Reference ViteHub error codes and the local proof path for each primitive.
-navigation.order: 1
-navigation.group: Diagnostics
+navigation.order: 58
+navigation.group: Runtime and output
 icon: i-lucide-circle-alert
 ---
 

--- a/docs/content/docs/reference/errors-diagnostics.md
+++ b/docs/content/docs/reference/errors-diagnostics.md
@@ -1,8 +1,8 @@
 ---
 title: Errors and diagnostics
 description: Reference ViteHub error codes and the local proof path for each primitive.
-navigation.order: 58
-navigation.group: Runtime and output
+navigation.order: 1
+navigation.group: Diagnostics
 icon: i-lucide-circle-alert
 ---
 

--- a/packages/agent/README.md
+++ b/packages/agent/README.md
@@ -260,7 +260,7 @@ Public HTTP errors keep the `ViteHubError` mapping. An unrecognized diagnostic
 maps to the generic `INTERNAL` response. Approval and cancellation behavior does
 not change.
 
-See [Errors and diagnostics](https://vitehub.dev/docs/reference/errors-diagnostics)
+See [Errors and diagnostics](https://vitehub.dev/docs/reference/diagnostics)
 for the code format and an application catalog example.
 
 ## Chat state

--- a/packages/agent/src/agent-diagnostics.ts
+++ b/packages/agent/src/agent-diagnostics.ts
@@ -453,7 +453,7 @@ const dynamicError = {
 
 // Throw-only diagnostics. The CLI and model adapters choose how to report them.
 export const agentDiagnostics = defineDiagnostics({
-  docsBase: () => "https://vitehub.dev/docs/reference/errors-diagnostics#agent-diagnostics",
+  docsBase: () => "https://vitehub.dev/docs/reference/diagnostics#agent-diagnostics",
   codes: {
     AGENT_R0907: dynamicError,
     AGENT_R0908: dynamicError,

--- a/packages/agent/src/http-error.ts
+++ b/packages/agent/src/http-error.ts
@@ -13,7 +13,7 @@ export class AgentHttpError extends Diagnostic {
   readonly statusCode: number
 
   constructor(statusCode: number, message: string) {
-    super({ code: "AGENT_R0891", docs: "https://vitehub.dev/docs/reference/errors-diagnostics#agent-diagnostics", why: message }, AgentHttpError)
+    super({ code: "AGENT_R0891", docs: "https://vitehub.dev/docs/reference/diagnostics#agent-diagnostics", why: message }, AgentHttpError)
     this.name = "AgentHttpError"
     this.status = statusCode
     this.statusCode = statusCode

--- a/packages/agent/src/index.ts
+++ b/packages/agent/src/index.ts
@@ -3239,7 +3239,7 @@ class AgentTelemetryCapabilityError extends Diagnostic {
     super({
       cause,
       code: "AGENT_R0890",
-      docs: "https://vitehub.dev/docs/reference/errors-diagnostics#agent-diagnostics",
+      docs: "https://vitehub.dev/docs/reference/diagnostics#agent-diagnostics",
       why: `[vitehub] Capability "${capabilityId}" telemetry export failed.`,
     }, AgentTelemetryCapabilityError)
     this.name = "AgentTelemetryCapabilityError"

--- a/packages/agent/src/server/github-host.ts
+++ b/packages/agent/src/server/github-host.ts
@@ -109,7 +109,7 @@ class GitHubRateLimitError extends Diagnostic {
     super({
       cause,
       code: "AGENT_R0889",
-      docs: "https://vitehub.dev/docs/reference/errors-diagnostics#agent-diagnostics",
+      docs: "https://vitehub.dev/docs/reference/diagnostics#agent-diagnostics",
       why: `GitHub GraphQL work for ${repository} is queued until ${new Date(limit.resetAt).toISOString()} (${limit.remaining} points remaining).`,
     }, GitHubRateLimitError)
     this.name = "GitHubRateLimitError"

--- a/packages/auth/src/error-diagnostics.ts
+++ b/packages/auth/src/error-diagnostics.ts
@@ -6,7 +6,7 @@ const dynamicError = {
 
 // Each code identifies one ViteHub failure site. Keep published codes stable.
 export const authErrorDiagnostics = /*#__PURE__*/ defineDiagnostics({
-  docsBase: () => "https://vitehub.dev/docs/reference/errors-diagnostics",
+  docsBase: () => "https://vitehub.dev/docs/reference/diagnostics",
   codes: {
     AUTH_R0001: dynamicError,
     AUTH_R0002: dynamicError,

--- a/packages/blob/README.md
+++ b/packages/blob/README.md
@@ -118,7 +118,7 @@ await fetch(upload.url, {
 })
 ```
 
-Blob operations return `[error, value]`. Provider and storage failures use `ViteHubError` with a stable `BLOB_*` code, operation/store details, and the provider failure in `cause`. Invalid arguments, unknown stores, and unsupported signing capabilities throw Nostics diagnostics with package-owned `BLOB_C####`, `BLOB_B####`, or `BLOB_R####` codes. Catch these defects by code. See [Errors and diagnostics](https://vitehub.dev/docs/reference/errors-diagnostics).
+Blob operations return `[error, value]`. Provider and storage failures use `ViteHubError` with a stable `BLOB_*` code, operation/store details, and the provider failure in `cause`. Invalid arguments, unknown stores, and unsupported signing capabilities throw Nostics diagnostics with package-owned `BLOB_C####`, `BLOB_B####`, or `BLOB_R####` codes. Catch these defects by code. See [Errors and diagnostics](https://vitehub.dev/docs/reference/diagnostics).
 
 The returned headers are part of the request contract and must be sent unchanged. `createOnly` prevents overwriting an existing object when the driver can enforce a conditional upload.
 

--- a/packages/blob/src/error-diagnostics.ts
+++ b/packages/blob/src/error-diagnostics.ts
@@ -6,7 +6,7 @@ const dynamicError = {
 
 // Each code identifies one ViteHub failure site. Keep published codes stable.
 export const blobErrorDiagnostics = /*#__PURE__*/ defineDiagnostics({
-  docsBase: () => "https://vitehub.dev/docs/reference/errors-diagnostics",
+  docsBase: () => "https://vitehub.dev/docs/reference/diagnostics",
   codes: {
     BLOB_R0027: dynamicError,
     BLOB_C0001: dynamicError,

--- a/packages/blob/src/runtime/storage.ts
+++ b/packages/blob/src/runtime/storage.ts
@@ -11,7 +11,7 @@ import { blobErrorDiagnostics } from "../error-diagnostics.ts"
 
 class UnknownBlobStoreError extends Diagnostic {
   constructor(message: string) {
-    super({ code: "BLOB_R0027", docs: "https://vitehub.dev/docs/reference/errors-diagnostics", why: message }, UnknownBlobStoreError)
+    super({ code: "BLOB_R0027", docs: "https://vitehub.dev/docs/reference/diagnostics", why: message }, UnknownBlobStoreError)
     this.name = "UnknownBlobStoreError"
   }
 }

--- a/packages/box/src/error-diagnostics.ts
+++ b/packages/box/src/error-diagnostics.ts
@@ -6,7 +6,7 @@ const dynamicError = {
 
 // Each code identifies one ViteHub failure site. Keep published codes stable.
 export const boxErrorDiagnostics = /*#__PURE__*/ defineDiagnostics({
-  docsBase: () => "https://vitehub.dev/docs/reference/errors-diagnostics",
+  docsBase: () => "https://vitehub.dev/docs/reference/diagnostics",
   codes: {
     BOX_R0001: dynamicError,
     BOX_R0002: dynamicError,

--- a/packages/browser/src/error-diagnostics.ts
+++ b/packages/browser/src/error-diagnostics.ts
@@ -6,7 +6,7 @@ const dynamicError = {
 
 // Each code identifies one ViteHub failure site. Keep published codes stable.
 export const browserErrorDiagnostics = /*#__PURE__*/ defineDiagnostics({
-  docsBase: () => "https://vitehub.dev/docs/reference/errors-diagnostics",
+  docsBase: () => "https://vitehub.dev/docs/reference/diagnostics",
   codes: {
     BROWSER_R0001: dynamicError,
     BROWSER_R0002: dynamicError,

--- a/packages/channels/src/error-diagnostics.ts
+++ b/packages/channels/src/error-diagnostics.ts
@@ -6,7 +6,7 @@ const dynamicError = {
 
 // Each code identifies one ViteHub failure site. Keep published codes stable.
 export const channelsErrorDiagnostics = /*#__PURE__*/ defineDiagnostics({
-  docsBase: () => "https://vitehub.dev/docs/reference/errors-diagnostics",
+  docsBase: () => "https://vitehub.dev/docs/reference/diagnostics",
   codes: {
     CHANNELS_R0001: dynamicError,
     CHANNELS_C0001: dynamicError,

--- a/packages/cli/src/error-diagnostics.ts
+++ b/packages/cli/src/error-diagnostics.ts
@@ -6,7 +6,7 @@ const dynamicError = {
 
 // Each code identifies one ViteHub failure site. Keep published codes stable.
 export const cliErrorDiagnostics = /*#__PURE__*/ defineDiagnostics({
-  docsBase: () => "https://vitehub.dev/docs/reference/errors-diagnostics",
+  docsBase: () => "https://vitehub.dev/docs/reference/diagnostics",
   codes: {
     CLI_R0001: dynamicError,
     CLI_R0002: dynamicError,

--- a/packages/content/src/error-diagnostics.ts
+++ b/packages/content/src/error-diagnostics.ts
@@ -6,7 +6,7 @@ const dynamicError = {
 
 // Each code identifies one ViteHub failure site. Keep published codes stable.
 export const contentErrorDiagnostics = /*#__PURE__*/ defineDiagnostics({
-  docsBase: () => "https://vitehub.dev/docs/reference/errors-diagnostics",
+  docsBase: () => "https://vitehub.dev/docs/reference/diagnostics",
   codes: {
     CONTENT_R0001: dynamicError,
     CONTENT_R0002: dynamicError,

--- a/packages/database/src/error-diagnostics.ts
+++ b/packages/database/src/error-diagnostics.ts
@@ -6,7 +6,7 @@ const dynamicError = {
 
 // Each code identifies one ViteHub failure site. Keep published codes stable.
 export const databaseErrorDiagnostics = /*#__PURE__*/ defineDiagnostics({
-  docsBase: () => "https://vitehub.dev/docs/reference/errors-diagnostics",
+  docsBase: () => "https://vitehub.dev/docs/reference/diagnostics",
   codes: {
     DATABASE_C0001: dynamicError,
     DATABASE_C0002: dynamicError,

--- a/packages/email/src/error-diagnostics.ts
+++ b/packages/email/src/error-diagnostics.ts
@@ -6,7 +6,7 @@ const dynamicError = {
 
 // Each code identifies one ViteHub failure site. Keep published codes stable.
 export const emailErrorDiagnostics = /*#__PURE__*/ defineDiagnostics({
-  docsBase: () => "https://vitehub.dev/docs/reference/errors-diagnostics",
+  docsBase: () => "https://vitehub.dev/docs/reference/diagnostics",
   codes: {
     EMAIL_R0001: dynamicError,
     EMAIL_R0002: dynamicError,

--- a/packages/env/src/error-diagnostics.ts
+++ b/packages/env/src/error-diagnostics.ts
@@ -6,7 +6,7 @@ const dynamicError = {
 
 // Each code identifies one ViteHub failure site. Keep published codes stable.
 export const envErrorDiagnostics = /*#__PURE__*/ defineDiagnostics({
-  docsBase: () => "https://vitehub.dev/docs/reference/errors-diagnostics",
+  docsBase: () => "https://vitehub.dev/docs/reference/diagnostics",
   codes: {
     ENV_R0001: dynamicError,
     ENV_R0002: dynamicError,

--- a/packages/internal/src/error-diagnostics.ts
+++ b/packages/internal/src/error-diagnostics.ts
@@ -6,7 +6,7 @@ const dynamicError = {
 
 // Each code identifies one ViteHub failure site. Keep published codes stable.
 export const internalErrorDiagnostics = /*#__PURE__*/ defineDiagnostics({
-  docsBase: () => "https://vitehub.dev/docs/reference/errors-diagnostics",
+  docsBase: () => "https://vitehub.dev/docs/reference/diagnostics",
   codes: {
     INTERNAL_R0012: dynamicError,
     INTERNAL_R0013: dynamicError,

--- a/packages/internal/src/http-request.ts
+++ b/packages/internal/src/http-request.ts
@@ -86,7 +86,7 @@ const httpEffectBoundary = createEffectBoundary({
 
 class HttpStatusError extends Diagnostic {
   constructor(readonly status: number) {
-    super({ code: "INTERNAL_R0012", docs: "https://vitehub.dev/docs/reference/errors-diagnostics", why: `[vitehub] HTTP request failed with status ${status}.` }, HttpStatusError)
+    super({ code: "INTERNAL_R0012", docs: "https://vitehub.dev/docs/reference/diagnostics", why: `[vitehub] HTTP request failed with status ${status}.` }, HttpStatusError)
     this.name = "HttpStatusError"
   }
 }

--- a/packages/internal/src/provision.ts
+++ b/packages/internal/src/provision.ts
@@ -88,7 +88,7 @@ export class ProvisionRequestError extends Diagnostic {
 
   constructor(method: string, path: string, status: number, codes: readonly (number | string)[] = []) {
     const suffix = codes.length ? ` Provider code${codes.length === 1 ? "" : "s"}: ${codes.join(", ")}.` : ""
-    super({ code: "INTERNAL_R0013", docs: "https://vitehub.dev/docs/reference/errors-diagnostics", why: `Provision request failed: ${method} ${path} (${status}).${suffix}` }, ProvisionRequestError)
+    super({ code: "INTERNAL_R0013", docs: "https://vitehub.dev/docs/reference/diagnostics", why: `Provision request failed: ${method} ${path} (${status}).${suffix}` }, ProvisionRequestError)
     this.name = "ProvisionRequestError"
     this.codes = codes
     this.status = status

--- a/packages/kv/src/error-diagnostics.ts
+++ b/packages/kv/src/error-diagnostics.ts
@@ -6,7 +6,7 @@ const dynamicError = {
 
 // Each code identifies one ViteHub failure site. Keep published codes stable.
 export const kvErrorDiagnostics = /*#__PURE__*/ defineDiagnostics({
-  docsBase: () => "https://vitehub.dev/docs/reference/errors-diagnostics",
+  docsBase: () => "https://vitehub.dev/docs/reference/diagnostics",
   codes: {
     KV_R0013: dynamicError,
     KV_R0014: dynamicError,

--- a/packages/kv/src/runtime/hosted-storage.ts
+++ b/packages/kv/src/runtime/hosted-storage.ts
@@ -21,7 +21,7 @@ export interface RuntimeStorage {
 
 export class KVStoreConfigurationError extends Diagnostic {
   constructor(message: string, options?: ErrorOptions, code = "KV_R0013") {
-    super({ cause: options?.cause, code, docs: "https://vitehub.dev/docs/reference/errors-diagnostics", why: message }, KVStoreConfigurationError)
+    super({ cause: options?.cause, code, docs: "https://vitehub.dev/docs/reference/diagnostics", why: message }, KVStoreConfigurationError)
     this.name = "KVStoreConfigurationError"
   }
 }

--- a/packages/markdown-template/src/error-diagnostics.ts
+++ b/packages/markdown-template/src/error-diagnostics.ts
@@ -6,7 +6,7 @@ const dynamicError = {
 
 // Each code identifies one ViteHub failure site. Keep published codes stable.
 export const markdownTemplateErrorDiagnostics = /*#__PURE__*/ defineDiagnostics({
-  docsBase: () => "https://vitehub.dev/docs/reference/errors-diagnostics",
+  docsBase: () => "https://vitehub.dev/docs/reference/diagnostics",
   codes: {
     MARKDOWN_TEMPLATE_R0001: dynamicError,
     MARKDOWN_TEMPLATE_R0002: dynamicError,

--- a/packages/queue/src/error-diagnostics.ts
+++ b/packages/queue/src/error-diagnostics.ts
@@ -6,7 +6,7 @@ const dynamicError = {
 
 // Each code identifies one ViteHub failure site. Keep published codes stable.
 export const queueErrorDiagnostics = /*#__PURE__*/ defineDiagnostics({
-  docsBase: () => "https://vitehub.dev/docs/reference/errors-diagnostics",
+  docsBase: () => "https://vitehub.dev/docs/reference/diagnostics",
   codes: {
     QUEUE_C0001: dynamicError,
     QUEUE_C0002: dynamicError,

--- a/packages/rate-limit/README.md
+++ b/packages/rate-limit/README.md
@@ -100,7 +100,7 @@ Cloudflare enforcement is best-effort, location-scoped, and limited to `10s` and
 
 Use `createRateLimiter()` when the application selects the driver and handles the decision. A production driver must implement one atomic `consume()` operation for its backend. A generic KV `get()` followed by `set()` is not safe under concurrent requests.
 
-Drivers return `[null, result]` after consuming the counter. They return `[error, undefined]` only for an expected operational outage. The limiter then returns `reason: "unavailable"` and sets `allowed` from the failure policy, which defaults to deny. ViteHub-owned configuration errors, malformed provider results, and implementation defects throw Nostics diagnostics with `RATE_LIMIT_B####` or `RATE_LIMIT_R####` codes. Application driver errors keep their identity. See [Errors and diagnostics](https://vitehub.dev/docs/reference/errors-diagnostics).
+Drivers return `[null, result]` after consuming the counter. They return `[error, undefined]` only for an expected operational outage. The limiter then returns `reason: "unavailable"` and sets `allowed` from the failure policy, which defaults to deny. ViteHub-owned configuration errors, malformed provider results, and implementation defects throw Nostics diagnostics with `RATE_LIMIT_B####` or `RATE_LIMIT_R####` codes. Application driver errors keep their identity. See [Errors and diagnostics](https://vitehub.dev/docs/reference/diagnostics).
 
 The limiter exposes its resolved `policy` and the driver's declared `capabilities`, including enforcement, counter scope, rejected-attempt behavior, and supported windows. Inspect them when deciding whether a driver fits a deployment.
 

--- a/packages/rate-limit/src/error-diagnostics.ts
+++ b/packages/rate-limit/src/error-diagnostics.ts
@@ -6,7 +6,7 @@ const dynamicError = {
 
 // Each code identifies one ViteHub failure site. Keep published codes stable.
 export const rateLimitErrorDiagnostics = /*#__PURE__*/ defineDiagnostics({
-  docsBase: () => "https://vitehub.dev/docs/reference/errors-diagnostics",
+  docsBase: () => "https://vitehub.dev/docs/reference/diagnostics",
   codes: {
     RATE_LIMIT_R0001: dynamicError,
     RATE_LIMIT_R0002: dynamicError,

--- a/packages/realtime/src/error-diagnostics.ts
+++ b/packages/realtime/src/error-diagnostics.ts
@@ -6,7 +6,7 @@ const dynamicError = {
 
 // Each code identifies one ViteHub failure site. Keep published codes stable.
 export const realtimeErrorDiagnostics = /*#__PURE__*/ defineDiagnostics({
-  docsBase: () => "https://vitehub.dev/docs/reference/errors-diagnostics",
+  docsBase: () => "https://vitehub.dev/docs/reference/diagnostics",
   codes: {
     REALTIME_R0013: dynamicError,
     REALTIME_R0001: dynamicError,

--- a/packages/realtime/src/server.ts
+++ b/packages/realtime/src/server.ts
@@ -138,7 +138,7 @@ export function realtimeRoomKey(definitionName: string, documentId: string): str
 
 class AwarenessOwnershipConflict extends Diagnostic {
   constructor() {
-    super({ code: "REALTIME_R0013", docs: "https://vitehub.dev/docs/reference/errors-diagnostics", why: "Awareness client id is already owned by another peer." }, AwarenessOwnershipConflict)
+    super({ code: "REALTIME_R0013", docs: "https://vitehub.dev/docs/reference/diagnostics", why: "Awareness client id is already owned by another peer." }, AwarenessOwnershipConflict)
     this.name = "AwarenessOwnershipConflict"
   }
 }

--- a/packages/runtime/README.md
+++ b/packages/runtime/README.md
@@ -144,7 +144,7 @@ that inspect the Error instance.
 
 ### Developer diagnostics
 
-Runtime-owned API and contract defects use Nostics diagnostics with stable `RUNTIME_R####` codes. Expected portable failures keep the `ViteHubError` public contract. See [Errors and diagnostics](https://vitehub.dev/docs/reference/errors-diagnostics).
+Runtime-owned API and contract defects use Nostics diagnostics with stable `RUNTIME_R####` codes. Expected portable failures keep the `ViteHubError` public contract. See [Errors and diagnostics](https://vitehub.dev/docs/reference/diagnostics).
 
 `normalizeRuntimeDiagnosticError(error)` creates a bounded diagnostic record. It
 preserves Nostics codes, fixes, documentation links, and source locations from

--- a/packages/runtime/src/error-diagnostics.ts
+++ b/packages/runtime/src/error-diagnostics.ts
@@ -6,7 +6,7 @@ const dynamicError = {
 
 // Each code identifies one ViteHub failure site. Keep published codes stable.
 export const runtimeErrorDiagnostics = /*#__PURE__*/ defineDiagnostics({
-  docsBase: () => "https://vitehub.dev/docs/reference/errors-diagnostics",
+  docsBase: () => "https://vitehub.dev/docs/reference/diagnostics",
   codes: {
     RUNTIME_R0001: dynamicError,
     RUNTIME_R0002: dynamicError,

--- a/packages/sandbox/src/error-diagnostics.ts
+++ b/packages/sandbox/src/error-diagnostics.ts
@@ -6,7 +6,7 @@ const dynamicError = {
 
 // Each code identifies one ViteHub failure site. Keep published codes stable.
 export const sandboxErrorDiagnostics = /*#__PURE__*/ defineDiagnostics({
-  docsBase: () => "https://vitehub.dev/docs/reference/errors-diagnostics",
+  docsBase: () => "https://vitehub.dev/docs/reference/diagnostics",
   codes: {
     SANDBOX_R0001: dynamicError,
     SANDBOX_R0002: dynamicError,

--- a/packages/schedule/src/error-diagnostics.ts
+++ b/packages/schedule/src/error-diagnostics.ts
@@ -6,7 +6,7 @@ const dynamicError = {
 
 // Each code identifies one ViteHub failure site. Keep published codes stable.
 export const scheduleErrorDiagnostics = /*#__PURE__*/ defineDiagnostics({
-  docsBase: () => "https://vitehub.dev/docs/reference/errors-diagnostics",
+  docsBase: () => "https://vitehub.dev/docs/reference/diagnostics",
   codes: {
     SCHEDULE_C0001: dynamicError,
     SCHEDULE_C0002: dynamicError,

--- a/packages/shell/src/error-diagnostics.ts
+++ b/packages/shell/src/error-diagnostics.ts
@@ -6,7 +6,7 @@ const dynamicError = {
 
 // Each code identifies one ViteHub failure site. Keep published codes stable.
 export const shellErrorDiagnostics = /*#__PURE__*/ defineDiagnostics({
-  docsBase: () => "https://vitehub.dev/docs/reference/errors-diagnostics",
+  docsBase: () => "https://vitehub.dev/docs/reference/diagnostics",
   codes: {
     SHELL_R0001: dynamicError,
     SHELL_R0002: dynamicError,

--- a/packages/source/src/core/collection.ts
+++ b/packages/source/src/core/collection.ts
@@ -200,7 +200,7 @@ export class CollectionCursorError extends Diagnostic {
     super({
       cause: options?.cause,
       code: "SOURCE_R0023",
-      docs: "https://vitehub.dev/docs/reference/errors-diagnostics",
+      docs: "https://vitehub.dev/docs/reference/diagnostics",
       why: message,
     }, CollectionCursorError)
     this.name = "CollectionCursorError"

--- a/packages/source/src/error-diagnostics.ts
+++ b/packages/source/src/error-diagnostics.ts
@@ -6,7 +6,7 @@ const dynamicError = {
 
 // Each code identifies one ViteHub failure site. Keep published codes stable.
 export const sourceErrorDiagnostics = /*#__PURE__*/ defineDiagnostics({
-  docsBase: () => "https://vitehub.dev/docs/reference/errors-diagnostics",
+  docsBase: () => "https://vitehub.dev/docs/reference/diagnostics",
   codes: {
     SOURCE_R0023: dynamicError,
     SOURCE_R0001: dynamicError,

--- a/packages/ui/src/error-diagnostics.ts
+++ b/packages/ui/src/error-diagnostics.ts
@@ -6,7 +6,7 @@ const dynamicError = {
 
 // Each code identifies one ViteHub failure site. Keep published codes stable.
 export const uiErrorDiagnostics = /*#__PURE__*/ defineDiagnostics({
-  docsBase: () => "https://vitehub.dev/docs/reference/errors-diagnostics",
+  docsBase: () => "https://vitehub.dev/docs/reference/diagnostics",
   codes: {
     UI_R0001: dynamicError,
     UI_R0002: dynamicError,

--- a/packages/vite-hub/src/console/runtime/client/request.ts
+++ b/packages/vite-hub/src/console/runtime/client/request.ts
@@ -15,7 +15,7 @@ export class ConsoleRequestError extends Diagnostic {
   readonly status: number
 
   constructor(status: number, message = `Console request failed with status ${status}.`) {
-    super({ code: "VITE_HUB_R0110", docs: "https://vitehub.dev/docs/reference/errors-diagnostics", why: message }, ConsoleRequestError)
+    super({ code: "VITE_HUB_R0110", docs: "https://vitehub.dev/docs/reference/diagnostics", why: message }, ConsoleRequestError)
     this.name = "ConsoleRequestError"
     this.status = status
   }

--- a/packages/vite-hub/src/error-diagnostics.ts
+++ b/packages/vite-hub/src/error-diagnostics.ts
@@ -6,7 +6,7 @@ const dynamicError = {
 
 // Each code identifies one ViteHub failure site. Keep published codes stable.
 export const viteHubErrorDiagnostics = /*#__PURE__*/ defineDiagnostics({
-  docsBase: () => "https://vitehub.dev/docs/reference/errors-diagnostics",
+  docsBase: () => "https://vitehub.dev/docs/reference/diagnostics",
   codes: {
     VITE_HUB_R0116: dynamicError,
     VITE_HUB_R0117: dynamicError,

--- a/packages/workflow/src/error-diagnostics.ts
+++ b/packages/workflow/src/error-diagnostics.ts
@@ -6,7 +6,7 @@ const dynamicError = {
 
 // Each code identifies one ViteHub failure site. Keep published codes stable.
 export const workflowErrorDiagnostics = /*#__PURE__*/ defineDiagnostics({
-  docsBase: () => "https://vitehub.dev/docs/reference/errors-diagnostics",
+  docsBase: () => "https://vitehub.dev/docs/reference/diagnostics",
   codes: {
     WORKFLOW_C0001: dynamicError,
     WORKFLOW_C0002: dynamicError,

--- a/packages/workspace/src/error-diagnostics.ts
+++ b/packages/workspace/src/error-diagnostics.ts
@@ -6,7 +6,7 @@ const dynamicError = {
 
 // Each code identifies one ViteHub failure site. Keep published codes stable.
 export const workspaceErrorDiagnostics = /*#__PURE__*/ defineDiagnostics({
-  docsBase: () => "https://vitehub.dev/docs/reference/errors-diagnostics",
+  docsBase: () => "https://vitehub.dev/docs/reference/diagnostics",
   codes: {
     WORKSPACE_R0067: dynamicError,
     WORKSPACE_R0068: dynamicError,

--- a/packages/workspace/src/providers/github/shared.ts
+++ b/packages/workspace/src/providers/github/shared.ts
@@ -100,7 +100,7 @@ export async function requestGitHub(input: string | URL, init: RequestInit = {})
 
 class GitHubRequestError extends Diagnostic {
   constructor(message: string, readonly status: number) {
-    super({ code: "WORKSPACE_R0068", docs: "https://vitehub.dev/docs/reference/errors-diagnostics", why: message }, GitHubRequestError);
+    super({ code: "WORKSPACE_R0068", docs: "https://vitehub.dev/docs/reference/diagnostics", why: message }, GitHubRequestError);
     this.name = "GitHubRequestError";
   }
 }

--- a/packages/workspace/src/server.ts
+++ b/packages/workspace/src/server.ts
@@ -191,7 +191,7 @@ function isNotFoundError(error: unknown): boolean {
 
 class WorkspaceCollectionRequestError extends Diagnostic {
   constructor(message: string) {
-    super({ code: "WORKSPACE_R0067", docs: "https://vitehub.dev/docs/reference/errors-diagnostics", why: message }, WorkspaceCollectionRequestError)
+    super({ code: "WORKSPACE_R0067", docs: "https://vitehub.dev/docs/reference/diagnostics", why: message }, WorkspaceCollectionRequestError)
     this.name = "WorkspaceCollectionRequestError"
   }
 }


### PR DESCRIPTION
Diagnostic links previously landed on the generic errors page, which made it difficult to find repair guidance and gave the diagnostics reference no focused navigation entry.

Add a dedicated `/docs/reference/diagnostics` page in a `Diagnostics` sidebar group. Route all package-owned diagnostic URLs to that page, while retaining the generic errors page for the shared `ViteHubError` contract. The page provides Agent and package guidance and a stable home for future generated code-specific pages.

The Agent catalog has about 949 codes. Thin pages for every code would create noisy navigation and duplicate low-value content; future generated pages should include unique remediation and examples.

Validation: documentation and URL updates only. Full docs tests were not run because workspace dependencies are unavailable in this checkout.

Model: GPT-6. Harness: Codex.
