### PR TITLE
feat(ui): copy message context

### DIFF
--- a/packages/ui/src/components/agent-invocation.ts
+++ b/packages/ui/src/components/agent-invocation.ts
@@ -1670,7 +1670,14 @@ export const AgentInvocation = defineComponent({
     async function copyMessage(activity: InvocationActivity) {
       try {
         if (!navigator.clipboard) throw new Error("Clipboard unavailable");
-        await navigator.clipboard.writeText(activity.body ?? "");
+        const url = agentInvocationExternalUrl(props.invocation);
+        const metadata = [
+          `Invocation ID: ${props.invocation.id}`,
+          `Trace ID: ${props.invocation.traceId}`,
+          props.invocation.agentName ? `Agent: ${props.invocation.agentName}` : undefined,
+          url ? `URL: ${url}` : undefined,
+        ].filter((value): value is string => value !== undefined);
+        await navigator.clipboard.writeText(`${activity.body ?? ""}\n\n${metadata.join("\n")}`);
         messageCopy.value = { id: activity.id, status: "copied" };
       }
       catch {

--- a/packages/ui/test/invocation-ui.test.ts
+++ b/packages/ui/test/invocation-ui.test.ts
@@ -892,8 +892,9 @@ describe("Agent Invocation UI", () => {
     const writeText = vi.fn().mockResolvedValue(undefined);
     Object.defineProperty(navigator, "clipboard", { configurable: true, value: { writeText } });
     const invocation = {
-      annotations: { triggeredBy: "Maxi", "channel.sentAt": "2026-08-22T14:34:00.000Z" },
+      annotations: { triggeredBy: "Maxi", "channel.sentAt": "2026-08-22T14:34:00.000Z", "github.url": "https://github.com/vite-hub/vite-hub/issues/18807" },
       createdAt: timestamp,
+      agentName: "support-agent",
       id: "message-meta",
       observations: [
         {
@@ -935,7 +936,7 @@ describe("Agent Invocation UI", () => {
     expect(prompt.get(".vh-invocation-message__meta time").attributes("datetime")).toBe("2026-08-22T14:34:00.000Z");
     await prompt.get('button[aria-label="Copy message"]').trigger("click");
     await nextTick();
-    expect(writeText).toHaveBeenCalledWith("Check item 18807.");
+    expect(writeText).toHaveBeenCalledWith("Check item 18807.\n\nInvocation ID: message-meta\nTrace ID: trace\nAgent: support-agent\nURL: https://github.com/vite-hub/vite-hub/issues/18807");
     expect(prompt.get('button[aria-label="Copied"]').text()).toBe("Copied");
   });
 


### PR DESCRIPTION
The console message copy action only copied the message body, which omitted the context needed to share or debug an invocation.

Copying a message now includes the full message followed by invocation ID, trace ID, agent name, and the safe external URL when one is available. The existing Copy/Copied state, clipboard failure handling, and accessible status announcements are preserved.

Validation: `corepack pnpm --dir packages/ui exec vp test test/invocation-ui.test.ts` (158 tests, no type errors).

Model: GPT-6
Harness: Codex
