### PR TITLE
fix(agent): defer provider readiness until input commands run

### DIFF
--- a/packages/agent/src/index.ts
+++ b/packages/agent/src/index.ts
@@ -3492,7 +3492,8 @@ async function createAgentInvocationContext<
     const readinessController = new AbortController()
     const readinessSignal = input.abortSignal ? AbortSignal.any([input.abortSignal, readinessController.signal]) : readinessController.signal
     const readinessTimer = driverKind === "provider" ? setTimeout(() => readinessController.abort(), 3_000) : undefined
-    const readiness = driverKind === "provider" && definition?.status
+    let readiness: Promise<Awaited<ReturnType<NonNullable<typeof definition>["status"]>> | undefined> | undefined
+    const resolveReadiness = () => readiness ||= driverKind === "provider" && definition?.status
       ? Promise.race([
           Promise.resolve().then(() => definition.status!(context, { abortSignal: readinessSignal })).catch(() => undefined),
           new Promise<undefined>(resolve => {
@@ -3620,19 +3621,20 @@ async function createAgentInvocationContext<
       resolveCapabilityCli,
       workspaceDefinition: resolvedWorkspaceDefinition,
     })
-    const knownUnavailable = readiness.then(status => {
+    const knownUnavailable = (capabilities: Awaited<typeof preparingCapabilities>) => resolveReadiness().then(status => {
       if (status?.readiness === "unavailable" && !status.stale) {
         const error = agentDiagnostics.AGENT_R0726({ message: status.reason || "The provider is unavailable." })
         preparationController.abort(error)
         // Setup may already own resources. Its scope closes on failure; a late successful
         // setup must also close even though the invocation has already reported the error.
-        const cleanup = preparingCapabilities.then(capabilities => capabilities.close(), () => undefined)
+        const cleanup = capabilities.close()
         context.waitUntil?.(cleanup)
         void cleanup.catch(() => undefined)
         throw error
       }
     })
-    const [capabilities] = await Promise.all([preparingCapabilities, knownUnavailable])
+    const capabilities = await preparingCapabilities
+    if (!capabilities.response) await knownUnavailable(capabilities)
     const inputHook = definition?.hooks?.["agent:input"]
     if (inputHook && !capabilities.response) {
       try {

--- a/packages/agent/src/index.ts
+++ b/packages/agent/src/index.ts
@@ -3489,19 +3489,25 @@ async function createAgentInvocationContext<
     // SAFETY: Agent definition normalization establishes the asserted internal Agent contract.
     const workspaceOptions = workspaceDefinition?.__vitehubWorkspaceAgentOptions as WorkspaceAgentOptions<AgentRuntimeConfig> | undefined
     const driverKind = internalDefinition?.[baseAgentDriverKind] || "model"
-    const readinessController = new AbortController()
-    const readinessSignal = input.abortSignal ? AbortSignal.any([input.abortSignal, readinessController.signal]) : readinessController.signal
-    const readinessTimer = driverKind === "provider" ? setTimeout(() => readinessController.abort(), 3_000) : undefined
-    let readiness: Promise<Awaited<ReturnType<NonNullable<typeof definition>["status"]>> | undefined> | undefined
-    const resolveReadiness = () => readiness ||= driverKind === "provider" && definition?.status
-      ? Promise.race([
+    const resolveReadiness = async () => {
+      if (driverKind !== "provider" || !definition?.status) return undefined
+      const readinessController = new AbortController()
+      const readinessSignal = input.abortSignal ? AbortSignal.any([input.abortSignal, readinessController.signal]) : readinessController.signal
+      const readinessTimer = setTimeout(() => readinessController.abort(), 3_000)
+      try {
+        return await Promise.race([
           Promise.resolve().then(() => definition.status!(context, { abortSignal: readinessSignal })).catch(() => undefined),
           new Promise<undefined>(resolve => {
             if (readinessSignal.aborted) resolve(undefined)
             else readinessSignal.addEventListener("abort", () => resolve(undefined), { once: true })
           }),
-        ]).finally(() => { clearTimeout(readinessTimer); readinessController.abort() })
-      : Promise.resolve(undefined)
+        ])
+      }
+      finally {
+        clearTimeout(readinessTimer)
+        readinessController.abort()
+      }
+    }
 
     const invocationResolvedCapabilities = capabilitiesResolver
       ? await resolveAgentCapabilityDefinitions(capabilitiesResolver, {
@@ -3625,8 +3631,7 @@ async function createAgentInvocationContext<
       if (status?.readiness === "unavailable" && !status.stale) {
         const error = agentDiagnostics.AGENT_R0726({ message: status.reason || "The provider is unavailable." })
         preparationController.abort(error)
-        // Setup may already own resources. Its scope closes on failure; a late successful
-        // setup must also close even though the invocation has already reported the error.
+        // Input preparation owns resources even when provider preflight fails.
         const cleanup = capabilities.close()
         context.waitUntil?.(cleanup)
         void cleanup.catch(() => undefined)

--- a/packages/agent/test/provider-status.test.ts
+++ b/packages/agent/test/provider-status.test.ts
@@ -4,6 +4,8 @@ import { tmpdir } from "node:os"
 import { dirname, join } from "node:path"
 import { afterEach, describe, expect, it, vi } from "vitest"
 
+vi.mock("#vitehub/agent/registry", () => ({ default: {} }))
+
 const inspectProvider = vi.hoisted(() => vi.fn())
 vi.mock("@t3tools/provider-runtime", () => ({ inspectProvider, createProviderRuntime: vi.fn(), createSqliteProviderRuntimeSessionStore: vi.fn() }))
 vi.mock("../src/internal/provider-runtime-packages.ts", () => ({ resolveInstalledProviderExecutable: () => "/fake/codex" }))
@@ -139,7 +141,7 @@ describe("provider inspection", () => {
 })
 
 describe("invocation preflight", () => {
-  it("rejects known unavailable capacity while preparation is still pending, then closes late resources", async () => {
+  it("checks unavailable capacity after preparation and closes its resources", async () => {
     const { defineAgent, defineCapability, runAgentInline } = await import("../src/index.ts")
     let release!: () => void
     let prepared!: () => void
@@ -149,25 +151,27 @@ describe("invocation preflight", () => {
     const background: Promise<unknown>[] = []
     const agent = defineAgent({ runtime: false, driver: { kind: "codex", model: "test" }, capabilities: [defineCapability({
       id: "slow-preparation", async prepare() { prepared(); await gate }, close,
-      input() { return new Response("handled") },
     })] })
-    vi.spyOn(agent, "status").mockImplementation(async () => {
+    const status = vi.spyOn(agent, "status").mockImplementation(async () => {
       await started
       return { agent: "test", checkedAt: new Date().toISOString(), readiness: "unavailable", stale: false, reason: "Workspace spend cap reached" }
     })
     const run = runAgentInline(agent, { runtime: "unknown", memo: (_key, create) => create(), waitUntil: task => { background.push(task) } }, { prompt: "hello" })
-    try { await expect(run).rejects.toMatchObject({ code: "AGENT_R0726", fix: expect.stringContaining("spending limit") }) }
-    finally { release() }
+    await started
+    expect(status).not.toHaveBeenCalled()
+    release()
+    await expect(run).rejects.toMatchObject({ code: "AGENT_R0726", fix: expect.stringContaining("spending limit") })
+    expect(status).toHaveBeenCalledTimes(1)
     await Promise.allSettled(background)
     expect(close).toHaveBeenCalledTimes(1)
   })
 
-  it("allows unknown readiness and never starts a model probe", async () => {
+  it("lets handled input respond without checking an unavailable provider", async () => {
     const { defineAgent, defineCapability, runAgentInline } = await import("../src/index.ts")
     const agent = defineAgent({ runtime: false, driver: { kind: "codex", model: "test" }, capabilities: [defineCapability({ id: "handled", input: () => new Response("handled") })] })
-    const status = vi.spyOn(agent, "status").mockResolvedValue({ agent: "test", readiness: "unknown", checkedAt: new Date().toISOString(), stale: false })
+    const status = vi.spyOn(agent, "status").mockResolvedValue({ agent: "test", readiness: "unavailable", checkedAt: new Date().toISOString(), stale: false })
     const result = await runAgentInline(agent, { runtime: "unknown", memo: (_key, create) => create(), waitUntil: task => void task.catch(() => {}) }, { prompt: "hello" })
     expect(await (result as Response).text()).toBe("handled")
-    expect(status).toHaveBeenCalledTimes(1)
+    expect(status).not.toHaveBeenCalled()
   })
 })


### PR DESCRIPTION
## Problem

Input commands that return a response should be able to handle a request before provider readiness checks run. A provider can be unavailable because of quota while a command such as `/debug` only needs to inspect an existing invocation and reply. Starting the readiness check in parallel means that unavailable provider state can fail the command path even though the command does not need the provider.

## Change

Defer provider readiness evaluation until capability input preparation completes. If input handling returns a response, readiness is never evaluated. If input handling continues, readiness is checked before agent input hooks and driver execution as before.

This preserves the existing `context.reply()` response short circuit and makes the ordering explicit at the invocation boundary.

## Validation

- `pnpm --filter @vite-hub/agent typecheck`

The Vitest binary is not present in this checkout, so the focused runtime tests could not be run locally.
