### PR TITLE
fix(docs): budget new esbuild warnings

### DIFF
--- a/docs/scripts/build.mjs
+++ b/docs/scripts/build.mjs
@@ -59,6 +59,16 @@ export const buildWarningBudget = Object.freeze([
     maximum: 1,
     text: '"H3Event" is imported from external module',
   },
+  {
+    name: "esbuild BigInt target warning",
+    maximum: 3,
+    text: "Big integer literals are not available in the configured target environment",
+  },
+  {
+    name: "esbuild duplicate provider warning",
+    maximum: 1,
+    text: 'Duplicate key "provider" in object literal',
+  },
 ]);
 
 export function assertBuildWarningBudget(output) {


### PR DESCRIPTION
The Cloudflare Workers docs build failed because Nuxt began emitting BigInt target and duplicate `provider` warnings that the docs warning budget treated as unknown.

This adds bounded warning budget entries for the three expected BigInt warnings and one duplicate provider warning, so the build continues to fail on unexpected warning changes.

Validation: `node --input-type=module` regression check for `assertBuildWarningBudget`; `git diff --check`; docs build reproduced the original failure before the fix.

Model and harness: OpenAI Codex (GPT-6), shell harness.
