### PR TITLE
fix(console): keep agent details closed during initial loading

### DIFF
--- a/packages/vite-hub/src/console/runtime/components/console-app.vue
+++ b/packages/vite-hub/src/console/runtime/components/console-app.vue
@@ -836,7 +836,6 @@ if (pageVisible.value) void loadAgents();
 onMounted(() => {
   media = window.matchMedia("(min-width: 981px)");
   updateDesktop();
-  detailsOpen.value = isDesktop.value;
   media.addEventListener("change", updateDesktop);
   document.addEventListener("visibilitychange", updatePageVisibility);
   updatePageVisibility();
@@ -1046,8 +1045,6 @@ onBeforeUnmount(() => {
           role="status"
         >
           <div
-            v-for="index in 6"
-            :key="index"
             class="grid grid-cols-[1rem_minmax(0,1fr)] gap-x-2 gap-y-2 rounded-md px-2 py-2.5"
           >
             <USkeleton class="mt-0.5 size-4 rounded" />
@@ -1056,7 +1053,7 @@ onBeforeUnmount(() => {
                 <USkeleton class="h-3 w-16 rounded" />
                 <USkeleton class="h-3 w-14 rounded" />
               </div>
-              <USkeleton class="h-4 rounded" :class="index % 3 === 0 ? 'w-3/4' : 'w-full'" />
+              <USkeleton class="h-4 w-full rounded" />
               <USkeleton class="h-3 w-2/3 rounded" />
             </div>
           </div>
@@ -1202,7 +1199,7 @@ onBeforeUnmount(() => {
             />
           </div>
           <USplitter
-            v-else-if="isDesktop && detailsOpen && (selectedInvocationId || initialSessionLoading)"
+            v-else-if="isDesktop && detailsOpen && selectedInvocationId"
             id="agent-session-layout"
             auto-save-id="vitehub-agent-session-layout-v2"
             :items="splitterItems"

--- a/packages/vite-hub/test/package.test.ts
+++ b/packages/vite-hub/test/package.test.ts
@@ -383,7 +383,7 @@ describe("framework package contract", () => {
       consolePage.indexOf("onMounted(() =>"),
     );
     expect(consolePage).toContain(
-      'v-else-if="isDesktop && detailsOpen && (selectedInvocationId || initialSessionLoading)"',
+      'v-else-if="isDesktop && detailsOpen && selectedInvocationId"',
     );
     expect(consolePage).toContain(
       'v-if="isDesktop && detailsOpen && detailsMaximized && selectedInvocationId"',
@@ -539,7 +539,7 @@ describe("framework package contract", () => {
     expect(consolePage).toContain('window.matchMedia("(min-width: 981px)")');
     expect(consolePage).toContain("root: 'md:flex'");
     expect(consolePage).toContain("content: 'md:hidden'");
-    expect(consolePage).toContain("detailsOpen.value = isDesktop.value");
+    expect(consolePage).toContain("const detailsOpen = ref(false)");
     expect(consolePage).toContain("}, 60_000);");
     expect(consolePage).toContain(
       "if (isRetryableConsoleRequestError(error)) scheduleAgentsRetry();",


### PR DESCRIPTION
The Console showed six sidebar loading rows and opened the details panel while the initial Agent/session data loaded. This made the loading state look like a three-column layout before a session was selected.

This change keeps the details panel closed by default, avoids mounting the split inspector during initial loading, and shows one compact sidebar placeholder while the main session skeleton loads.

Validation:
- `corepack pnpm exec vp run -t vite-hub#build`
- `corepack pnpm --dir packages/vite-hub exec vp test test/console-bootstrap.test.ts` (11 passed)
- `corepack pnpm --dir packages/vite-hub run typecheck`
- `corepack pnpm exec vp run lint` (passed with existing warnings)

No playground or browser checks ran.

Setup: `corepack pnpm install --frozen-lockfile` installed dependencies but failed in the docs postinstall step. The separate affected-package build and checks above passed.

Model: GPT-6. Harness: Codex in T3 Code.
