### PR TITLE
chore: trim Sandbox and Source runtime dependencies

### DIFF
--- a/packages/sandbox/package.json
+++ b/packages/sandbox/package.json
@@ -80,15 +80,11 @@
     "@vite-hub/box": "workspace:*",
     "@vite-hub/runtime": "workspace:*",
     "esbuild": "catalog:tooling",
-    "h3": "catalog:unjs",
     "local-pkg": "catalog:tooling",
     "mlly": "catalog:unjs",
     "nostics": "catalog:runtime",
     "pathe": "catalog:unjs",
-    "rollup": "catalog:tooling",
-    "scule": "catalog:unjs",
     "typescript": "catalog:tooling",
-    "ufo": "catalog:unjs",
     "unimport": "catalog:unjs",
     "yaml": "catalog:tooling"
   },
@@ -96,6 +92,7 @@
     "@vite-hub/internal": "workspace:*",
     "ofetch": "catalog:unjs",
     "publint": "catalog:tooling",
+    "rollup": "catalog:tooling",
     "vite": "catalog:vite",
     "vite-plus": "catalog:tooling",
     "vitest": "catalog:tooling"

--- a/packages/sandbox/src/internal/shared/named-resource.ts
+++ b/packages/sandbox/src/internal/shared/named-resource.ts
@@ -1,5 +1,8 @@
-import { upperFirst } from 'scule'
 import { sandboxErrorDiagnostics } from "../../error-diagnostics.ts"
+
+function upperFirst(value: string) {
+  return value.charAt(0).toUpperCase() + value.slice(1)
+}
 
 export function resolveNamedResourceName(feature: string, name: string | undefined) {
   if (!name)

--- a/packages/source/package.json
+++ b/packages/source/package.json
@@ -76,7 +76,6 @@
   "dependencies": {
     "@standard-schema/spec": "catalog:runtime",
     "@vite-hub/runtime": "workspace:*",
-    "effect": "catalog:effect",
     "h3": "catalog:unjs",
     "mlly": "catalog:unjs",
     "nostics": "catalog:runtime",
@@ -87,6 +86,7 @@
     "@types/node": "catalog:tooling",
     "@types/picomatch": "catalog:tooling",
     "@vite-hub/internal": "workspace:*",
+    "effect": "catalog:effect",
     "mrmime": "catalog:workspace",
     "ocache": "catalog:unjs",
     "picomatch": "catalog:workspace",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -368,12 +368,6 @@ catalogs:
     pathe:
       specifier: ^2.0.3
       version: 2.0.3
-    scule:
-      specifier: ^1.3.0
-      version: 1.3.0
-    ufo:
-      specifier: ^1.6.4
-      version: 1.6.4
     unimport:
       specifier: ^6.4.0
       version: 6.4.0
@@ -1759,9 +1753,6 @@ importers:
       esbuild:
         specifier: catalog:tooling
         version: 0.28.2
-      h3:
-        specifier: catalog:unjs
-        version: 2.0.1-rc.31(crossws@0.4.12(srvx@1.0.3))(ocache@0.3.0)
       local-pkg:
         specifier: catalog:tooling
         version: 1.2.1
@@ -1774,18 +1765,9 @@ importers:
       pathe:
         specifier: catalog:unjs
         version: 2.0.3
-      rollup:
-        specifier: catalog:tooling
-        version: 4.63.1
-      scule:
-        specifier: catalog:unjs
-        version: 1.3.0
       typescript:
         specifier: catalog:tooling
         version: 6.0.3
-      ufo:
-        specifier: catalog:unjs
-        version: 1.6.4
       unimport:
         specifier: catalog:unjs
         version: 6.4.0(@voidzero-dev/vite-plus-core@0.3.1(@types/node@26.4.1)(esbuild@0.28.2)(jiti@2.7.0)(publint@0.3.24)(terser@5.51.2)(tsx@4.21.0)(typescript@6.0.3)(unrun@0.2.36)(yaml@2.9.0))(esbuild@0.28.2)(oxc-parser@0.147.0)(rolldown@1.2.7)(rollup@4.63.1)
@@ -1805,6 +1787,9 @@ importers:
       publint:
         specifier: catalog:tooling
         version: 0.3.24
+      rollup:
+        specifier: catalog:tooling
+        version: 4.63.1
       vite-plus:
         specifier: catalog:tooling
         version: 0.3.1(@opentelemetry/api@1.9.1)(@types/node@26.4.1)(esbuild@0.28.2)(happy-dom@20.14.0)(jiti@2.7.0)(publint@0.3.24)(terser@5.51.2)(tsx@4.21.0)(typescript@6.0.3)(unrun@0.2.36)(yaml@2.9.0)
@@ -1935,9 +1920,6 @@ importers:
       '@vite-hub/runtime':
         specifier: workspace:*
         version: link:../runtime
-      effect:
-        specifier: catalog:effect
-        version: 4.0.0-rc.112
       h3:
         specifier: catalog:unjs
         version: 2.0.1-rc.31(crossws@0.4.12(srvx@1.0.3))(ocache@0.3.0)
@@ -1966,6 +1948,9 @@ importers:
       '@vite-hub/internal':
         specifier: workspace:*
         version: link:../internal
+      effect:
+        specifier: catalog:effect
+        version: 4.0.0-rc.112
       mrmime:
         specifier: catalog:workspace
         version: 2.0.1

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -146,8 +146,6 @@ catalogs:
     ocache: ^0.3.0
     ofetch: ^1.5.1
     pathe: ^2.0.3
-    scule: ^1.3.0
-    ufo: ^1.6.4
     unimport: ^6.4.0
   vercel:
     "@vercel/functions": ^3.9.5

--- a/test/effect-ownership.test.ts
+++ b/test/effect-ownership.test.ts
@@ -23,6 +23,7 @@ const repoRoot = resolve(import.meta.dirname, "..")
 const effectVersion = "4.0.0-rc.112"
 const expectedEffectOwners = ["agent", "internal", "schedule", "source"]
 const allowedEffectOwners = new Set(expectedEffectOwners)
+const dependencyGroups = ["dependencies", "devDependencies", "optionalDependencies", "peerDependencies"]
 
 type PackageEffectOwnership = {
   declaresEffect: boolean
@@ -84,7 +85,6 @@ async function packageEffectOwnership(): Promise<PackageEffectOwnership[]> {
     const sources = await readFiles(join(packageDir, "src"), path => /\.[cm]?[jt]sx?$/.test(path))
     const manifestPath = join(packageDir, "package.json")
     const manifest = parseJsonObject(await readFile(manifestPath, "utf8"), manifestPath)
-    const dependencyGroups = ["dependencies", "devDependencies", "optionalDependencies", "peerDependencies"]
     const declaresEffect = dependencyGroups.some((group) => {
       const dependencies = manifest[group]
       return isJsonObject(dependencies) && "effect" in dependencies
@@ -140,10 +140,12 @@ describe("Effect ownership", () => {
       const packageDir = join(repoRoot, "packages", owner)
       const manifestPath = join(packageDir, "package.json")
       const manifest = parseJsonObject(await readFile(manifestPath, "utf8"), manifestPath)
-      const dependencies = manifest.dependencies
-      const devDependencies = manifest.devDependencies
-      const declaredEffect = isJsonObject(dependencies) ? dependencies.effect : isJsonObject(devDependencies) ? devDependencies.effect : undefined
-      expect(declaredEffect, manifestPath).toBe("catalog:effect")
+      for (const group of dependencyGroups) {
+        const dependencies = manifest[group]
+        if (isJsonObject(dependencies) && "effect" in dependencies) {
+          expect(dependencies.effect, `${manifestPath} ${group}`).toBe("catalog:effect")
+        }
+      }
 
       const effectPackage = createRequire(manifestPath).resolve("effect/package.json")
       const resolved = parseJsonObject(await readFile(effectPackage, "utf8"), effectPackage)
@@ -162,6 +164,12 @@ describe("Effect ownership", () => {
       expect(bundles, packageDir).not.toMatch(/effect@3\.|3\.17\.7/)
     }
   }, 30_000)
+
+  it("keeps Source's bundled Effect out of emitted JavaScript and declarations", async () => {
+    const sources = await readFiles(join(repoRoot, "packages/source/dist"), path => /\.[cm]?[jt]s$/.test(path))
+    expect(sources.length).toBeGreaterThan(0)
+    expect(sources.some(sourceImportsEffect)).toBe(false)
+  })
 
   it.each([
     {

--- a/test/effect-ownership.test.ts
+++ b/test/effect-ownership.test.ts
@@ -141,7 +141,8 @@ describe("Effect ownership", () => {
       const manifestPath = join(packageDir, "package.json")
       const manifest = parseJsonObject(await readFile(manifestPath, "utf8"), manifestPath)
       const dependencies = manifest.dependencies
-      const declaredEffect = isJsonObject(dependencies) ? dependencies.effect : undefined
+      const devDependencies = manifest.devDependencies
+      const declaredEffect = isJsonObject(dependencies) ? dependencies.effect : isJsonObject(devDependencies) ? devDependencies.effect : undefined
       expect(declaredEffect, manifestPath).toBe("catalog:effect")
 
       const effectPackage = createRequire(manifestPath).resolve("effect/package.json")


### PR DESCRIPTION
Sandbox installs packages it does not use at runtime, and Source declares Effect as a runtime dependency even though it bundles it. Remove Sandbox's h3, ufo and scule declarations, preserve diagnostic capitalization locally, and move Sandbox's private Rollup type dependency and Source's bundled Effect to devDependencies. Remove the unused catalogs and update the lockfile.

Public exports and emitted declarations are unchanged. This reduces direct runtime requirements; other packages can still install these dependencies transitively.

Validation:

- Full Sandbox suite: 344 passed. Full Source suite: 127 passed.
- Both package typechecks and builds, including publint, passed.
- Fresh emitted declarations match the baseline byte for byte. Built JavaScript and declarations have no imports from the removed dependencies.
- Full workspace build, repository lint, TypeScript doctor and Knip catalog check passed.
- Frozen lockfile installation passed.
- Root contracts: 349 passed on the full run; the remaining license-packaging test passed when rerun alone after a 30-second timeout. The updated Effect ownership contract accepts the pinned catalog in any dependency group and checks that Source emits no external Effect imports.
- The broader packed-consumer suite is running locally; its result will be added when complete.
