### PR TITLE
refactor(blob): share provider dependency mappings

### DIFF
--- a/packages/blob/src/internal/vite-build.ts
+++ b/packages/blob/src/internal/vite-build.ts
@@ -11,6 +11,7 @@ import { copyVercelFunctionRuntimePackages } from "@vite-hub/internal/build/verc
 import { isPlainObject } from "@vite-hub/internal/object"
 
 import { normalizeBlobOptions } from "../config.ts"
+import { filesSdkDriverPeers } from "./files-sdk-peers.ts"
 
 import type { BlobDriver, BlobModuleOptions, ResolvedBlobModuleOptions, ResolvedCloudflareR2BlobStoreConfig } from "../types.ts"
 import type { CloudflareProviderDeploymentOutput, ProviderDeploymentOutputGeneration, ProviderDeploymentOutputWriter, ProviderOutputCatalog, VercelProviderDeploymentOutput } from "@vite-hub/internal/build/deployment-output"
@@ -25,27 +26,6 @@ const productName = "blob"
 const packageDir = computePackageDir(import.meta.url)
 const resolveRuntimeModule = (modulePath: string) => resolveRuntimeFromPkg(packageDir, modulePath)
 const nodeBuiltinExternals = [...new Set(builtinModules.flatMap(name => name.startsWith("node:") ? [name] : [name, `node:${name}`]))]
-const s3ProviderPeers = ["@aws-sdk/client-s3", "@aws-sdk/lib-storage", "@aws-sdk/s3-presigned-post", "@aws-sdk/s3-request-presigner"] as const
-const buildFilesSdkDriverPeers = {
-  akamai: s3ProviderPeers,
-  azure: ["@azure/identity", "@azure/storage-blob"],
-  box: ["box-typescript-sdk-gen"],
-  "cloudflare-r2": s3ProviderPeers,
-  "digitalocean-spaces": s3ProviderPeers,
-  dropbox: ["dropbox"],
-  fs: [],
-  gcs: ["@google-cloud/storage"],
-  "google-drive": ["@googleapis/drive", "google-auth-library"],
-  hetzner: s3ProviderPeers,
-  minio: s3ProviderPeers,
-  "netlify-blobs": [],
-  onedrive: ["@azure/identity", "@microsoft/microsoft-graph-client"],
-  s3: s3ProviderPeers,
-  storj: s3ProviderPeers,
-  supabase: ["@supabase/storage-js"],
-  uploadthing: ["uploadthing"],
-  "vercel-blob": [],
-} satisfies Record<BlobDriver, readonly string[]>
 const BLOB_ENTRY_NAMES_DEFAULT = ["server.ts", "server.mts", "server.js", "server.mjs", "worker.ts", "worker.mts", "worker.js", "worker.mjs"] as const
 const BLOB_ENTRY_NAMES_PRIORITIZED = ["server.blob.ts", "server.blob.mts", "server.blob.js", "server.blob.mjs", ...BLOB_ENTRY_NAMES_DEFAULT] as const
 
@@ -527,7 +507,7 @@ function createVercelOutput(
 function getSelectedFilesSdkProviderPeers(blob: BlobModuleOptions | ResolvedBlobModuleOptions | undefined): string[] {
   const resolved = resolveBlobConfig(blob, "vercel")
   const stores = resolved === false ? [] : Object.values(resolved.stores || { default: resolved.store })
-  return [...new Set(stores.flatMap(store => buildFilesSdkDriverPeers[store.driver] ?? []))]
+  return [...new Set(stores.flatMap(store => filesSdkDriverPeers[store.driver] ?? []))]
 }
 
 function hasExplicitFsStore(blob: BlobModuleOptions | ResolvedBlobModuleOptions | undefined) {
@@ -575,7 +555,7 @@ function getVercelBlobRuntimePackages(blob: BlobModuleOptions | ResolvedBlobModu
   const resolved = resolveBlobConfig(blob, "vercel")
   const stores = resolved === false ? [] : Object.values(resolved.stores || { default: resolved.store })
   for (const store of stores) {
-    for (const name of buildFilesSdkDriverPeers[store.driver] ?? []) {
+    for (const name of filesSdkDriverPeers[store.driver] ?? []) {
       packages.add(name)
       filesSdkPeers.add(name)
     }

--- a/packages/blob/src/internal/vite-build.ts
+++ b/packages/blob/src/internal/vite-build.ts
@@ -13,7 +13,7 @@ import { isPlainObject } from "@vite-hub/internal/object"
 import { normalizeBlobOptions } from "../config.ts"
 import { filesSdkDriverPeers } from "./files-sdk-peers.ts"
 
-import type { BlobDriver, BlobModuleOptions, ResolvedBlobModuleOptions, ResolvedCloudflareR2BlobStoreConfig } from "../types.ts"
+import type { BlobModuleOptions, ResolvedBlobModuleOptions, ResolvedCloudflareR2BlobStoreConfig } from "../types.ts"
 import type { CloudflareProviderDeploymentOutput, ProviderDeploymentOutputGeneration, ProviderDeploymentOutputWriter, ProviderOutputCatalog, VercelProviderDeploymentOutput } from "@vite-hub/internal/build/deployment-output"
 import type { VercelFunctionRuntimePackage } from "@vite-hub/internal/build/vercel-runtime-packages"
 import { blobErrorDiagnostics } from "../error-diagnostics.ts"

--- a/packages/blob/vite.config.ts
+++ b/packages/blob/vite.config.ts
@@ -2,6 +2,8 @@ import { fileURLToPath } from "node:url";
 
 import { defineConfig } from "vite-plus";
 
+import { filesSdkDriverPeers } from "./src/internal/files-sdk-peers.ts";
+
 const bundledFilesSdkDrivers = new Set([
   "akamai",
   "azure",
@@ -20,22 +22,7 @@ const bundledFilesSdkDrivers = new Set([
   "uploadthing",
 ]);
 
-const filesSdkProviderPeers = [
-  "@aws-sdk/client-s3",
-  "@aws-sdk/lib-storage",
-  "@aws-sdk/s3-presigned-post",
-  "@aws-sdk/s3-request-presigner",
-  "@azure/identity",
-  "@azure/storage-blob",
-  "@google-cloud/storage",
-  "@googleapis/drive",
-  "@microsoft/microsoft-graph-client",
-  "@supabase/storage-js",
-  "box-typescript-sdk-gen",
-  "dropbox",
-  "google-auth-library",
-  "uploadthing",
-];
+const filesSdkProviderPeers = [...new Set(Object.values(filesSdkDriverPeers).flat())].sort();
 
 export default defineConfig({
   pack: {


### PR DESCRIPTION
Blob maintains the same provider SDK mapping separately for install guidance and deployment packaging, plus a third list for package externals. Use the existing filesSdkDriverPeers map for all three so adding or changing a provider's requirements has one owner.

Removes 33 net lines. Public exports, emitted declarations, SDK ordering, optional-peer diagnostics and native Cloudflare R2 behavior are unchanged.

Validation:

- Full Blob package suite: 247 tests passed, including type tests and packed private Vercel Blob / Cloudflare R2 consumer builds without provider SDKs at the consumer root.
- Package build, publint and typecheck passed.
- Emitted declarations match the baseline byte for byte.
- Repository lint, TypeScript doctor and git diff --check passed.

Independent PR against main; it does not depend on the dependency cleanup in #1374.
