### PR TITLE
refactor(shell): share command parsing and inspection metadata

### DIFF
--- a/packages/shell/src/command/analyze.ts
+++ b/packages/shell/src/command/analyze.ts
@@ -1,3 +1,5 @@
+import { splitShellCommandSegments } from "./parse.ts"
+
 import type { ShellAnalyzeOptions, ShellAnalyzeResult } from "../runtime/types.ts"
 import { shellErrorDiagnostics } from "../error-diagnostics.ts"
 
@@ -17,12 +19,15 @@ export async function analyzeShellCommand(
     }
   }
 
+  const segments = splitShellCommandSegments(command)
+  const commands = [...new Set(segments.map(segment => firstCommandWord(segment.command)).filter(name => name !== undefined))]
+
   try {
     await withTimeout(parseWithShSyntax(command), options.timeoutMs ?? defaultTimeoutMs)
   }
   catch (error) {
     return {
-      commands: detectCommandNames(command),
+      commands,
       error: error instanceof Error ? error.message : String(error),
       ok: false,
       parser: "sh-syntax",
@@ -30,10 +35,10 @@ export async function analyzeShellCommand(
   }
 
   return {
-    commands: detectCommandNames(command),
+    commands,
     hasCommandSubstitution: /(?:\$\(|`)/.test(command),
     hasHeredocs: /<<-?/.test(command),
-    hasPipelines: hasUnquoted(command, "|"),
+    hasPipelines: segments.some(segment => segment.separatorAfter === "|" || segment.separatorAfter === "||"),
     hasRedirects: /(?:^|[^<])(?:>>?|<)/.test(command),
     ok: true,
     parser: "sh-syntax",
@@ -61,58 +66,6 @@ async function withTimeout<T>(promise: Promise<T>, timeoutMs: number): Promise<T
   }
 }
 
-function detectCommandNames(command: string): string[] {
-  const names: string[] = []
-  for (const segment of splitShellCommandSegments(command)) {
-    const name = firstCommandWord(segment)
-    if (name && !names.includes(name)) names.push(name)
-  }
-  return names
-}
-
-export function splitShellCommandSegments(command: string): string[] {
-  const segments: string[] = []
-  let current = ""
-  let quote: "'" | "\"" | undefined
-  let escaped = false
-
-  for (let index = 0; index < command.length; index++) {
-    const char = command[index]!
-    const next = command[index + 1]
-
-    if (escaped) {
-      current += char
-      escaped = false
-      continue
-    }
-    if (char === "\\") {
-      current += char
-      escaped = true
-      continue
-    }
-    if (quote) {
-      if (char === quote) quote = undefined
-      current += char
-      continue
-    }
-    if (char === "'" || char === "\"") {
-      quote = char
-      current += char
-      continue
-    }
-    if (char === "|" || char === ";" || char === "\n" || (char === "&" && next === "&") || (char === "|" && next === "|")) {
-      segments.push(current)
-      current = ""
-      if ((char === "&" || char === "|") && next === char) index += 1
-      continue
-    }
-    current += char
-  }
-
-  segments.push(current)
-  return segments
-}
-
 function firstCommandWord(segment: string): string | undefined {
   const words = segment.trim().match(/[^\s]+/g) || []
   for (const word of words) {
@@ -121,30 +74,4 @@ function firstCommandWord(segment: string): string | undefined {
     return word.replace(/^command$/, "")
       || undefined
   }
-}
-
-function hasUnquoted(command: string, target: string): boolean {
-  let quote: "'" | "\"" | undefined
-  let escaped = false
-
-  for (const char of command) {
-    if (escaped) {
-      escaped = false
-      continue
-    }
-    if (char === "\\") {
-      escaped = true
-      continue
-    }
-    if (quote) {
-      if (char === quote) quote = undefined
-      continue
-    }
-    if (char === "'" || char === "\"") {
-      quote = char
-      continue
-    }
-    if (char === target) return true
-  }
-  return false
 }

--- a/packages/shell/src/command/parse.ts
+++ b/packages/shell/src/command/parse.ts
@@ -1,5 +1,6 @@
 import { shellErrorDiagnostics } from "../error-diagnostics.ts"
-export function parseShellCommand(command: string): string[] {
+
+export function parseShellCommand(command: string, mode: "execution" | "inspection" = "execution"): string[] {
   const words: string[] = []
   let current = ""
   let quote: "'" | "\"" | undefined
@@ -34,8 +35,65 @@ export function parseShellCommand(command: string): string[] {
     current += char
   }
 
-  if (escaped) current += "\\"
-  if (quote) throw shellErrorDiagnostics.SHELL_R0003({ message: "unterminated quote" })
+  if (mode === "execution") {
+    if (escaped) current += "\\"
+    if (quote) throw shellErrorDiagnostics.SHELL_R0003({ message: "unterminated quote" })
+  }
   if (current) words.push(current)
   return words
+}
+
+export function splitShellCommandSegments(command: string) {
+  const segments: Array<{ command: string, followsPipe: boolean, separatorAfter?: "&&" | "||" | "|" | ";" | "\n" }> = []
+  let current = ""
+  let quote: "'" | "\"" | undefined
+  let escaped = false
+  let followsPipe = false
+  for (let index = 0; index < command.length; index++) {
+    const char = command[index]!
+    if (escaped) {
+      current += char
+      escaped = false
+      continue
+    }
+    if (char === "\\") {
+      current += char
+      escaped = true
+      continue
+    }
+    if (quote) {
+      if (char === quote) quote = undefined
+      current += char
+      continue
+    }
+    if (char === "'" || char === "\"") {
+      quote = char
+      current += char
+      continue
+    }
+    const next = command[index + 1]
+    if (char === "&" && next === "&") {
+      segments.push({ command: current, followsPipe, separatorAfter: "&&" })
+      current = ""
+      followsPipe = false
+      index += 1
+      continue
+    }
+    if (char === "|" && next === "|") {
+      segments.push({ command: current, followsPipe, separatorAfter: "||" })
+      current = ""
+      followsPipe = false
+      index += 1
+      continue
+    }
+    if (char === "|" || char === ";" || char === "\n") {
+      segments.push({ command: current, followsPipe, separatorAfter: char })
+      current = ""
+      followsPipe = char === "|"
+      continue
+    }
+    current += char
+  }
+  segments.push({ command: current, followsPipe })
+  return segments
 }

--- a/packages/shell/src/workspace/command-analysis.ts
+++ b/packages/shell/src/workspace/command-analysis.ts
@@ -1,3 +1,5 @@
+import { parseShellCommand, splitShellCommandSegments } from "../command/parse.ts"
+
 export interface WorkspaceInspectionCommandSegment {
   command: string
   followsPipe: boolean
@@ -9,7 +11,7 @@ export interface WorkspaceInspectionCommandSegment {
 
 export function analyzeWorkspaceInspectionCommand(command: string): WorkspaceInspectionCommandSegment[] {
   return splitShellCommandSegments(command).map((segment) => {
-    const words = parseShellWords(segment.command)
+    const words = parseShellCommand(segment.command, "inspection")
     return {
       ...segment,
       paths: shellPathArguments(words),
@@ -226,61 +228,6 @@ function pathArgumentsUntilShellBoundary(args: string[]) {
   return paths
 }
 
-function splitShellCommandSegments(command: string) {
-  const segments: Array<{ command: string, followsPipe: boolean, separatorAfter?: "&&" | "||" | "|" | ";" | "\n" }> = []
-  let current = ""
-  let quote: "'" | "\"" | undefined
-  let escaped = false
-  let followsPipe = false
-  for (let index = 0; index < command.length; index++) {
-    const char = command[index]!
-    if (escaped) {
-      current += char
-      escaped = false
-      continue
-    }
-    if (char === "\\") {
-      current += char
-      escaped = true
-      continue
-    }
-    if (quote) {
-      if (char === quote) quote = undefined
-      current += char
-      continue
-    }
-    if (char === "'" || char === "\"") {
-      quote = char
-      current += char
-      continue
-    }
-    const next = command[index + 1]
-    if (char === "&" && next === "&") {
-      segments.push({ command: current, followsPipe, separatorAfter: "&&" })
-      current = ""
-      followsPipe = false
-      index += 1
-      continue
-    }
-    if (char === "|" && next === "|") {
-      segments.push({ command: current, followsPipe, separatorAfter: "||" })
-      current = ""
-      followsPipe = false
-      index += 1
-      continue
-    }
-    if (char === "|" || char === ";" || char === "\n") {
-      segments.push({ command: current, followsPipe, separatorAfter: char })
-      current = ""
-      followsPipe = char === "|"
-      continue
-    }
-    current += char
-  }
-  segments.push({ command: current, followsPipe })
-  return segments
-}
-
 function hasRecursiveGrepFlag(words: string[]) {
   const args = words.slice(1)
   for (let index = 0; index < args.length; index++) {
@@ -299,41 +246,4 @@ function hasRecursiveGrepFlag(words: string[]) {
     if (arg.includes("r") || arg.includes("R")) return true
   }
   return false
-}
-
-function parseShellWords(command: string) {
-  const words: string[] = []
-  let current = ""
-  let quote: "'" | "\"" | undefined
-  let escaped = false
-  for (const char of command) {
-    if (escaped) {
-      current += char
-      escaped = false
-      continue
-    }
-    if (char === "\\") {
-      escaped = true
-      continue
-    }
-    if (quote) {
-      if (char === quote) quote = undefined
-      else current += char
-      continue
-    }
-    if (char === "'" || char === "\"") {
-      quote = char
-      continue
-    }
-    if (/\s/.test(char)) {
-      if (current) {
-        words.push(current)
-        current = ""
-      }
-      continue
-    }
-    current += char
-  }
-  if (current) words.push(current)
-  return words
 }

--- a/packages/shell/test/runtime.test.ts
+++ b/packages/shell/test/runtime.test.ts
@@ -425,6 +425,27 @@ describe("@vite-hub/shell just-bash runtime", () => {
 })
 
 describe("@vite-hub/shell cloudflare runtime", () => {
+  it("preserves quoted arguments, escaped spaces and trailing backslashes when forwarding commands", async () => {
+    const exec = vi.fn(async () => ({ exitCode: 0, stderr: "", stdout: "" }))
+    const provider = createCloudflareShellProvider({
+      sandbox: { exec, supports: { execCwd: true, execEnv: true } },
+    })
+
+    await provider.exec("printf 'hello world' \"a|b\" space\\ value trailing\\")
+
+    expect(exec).toHaveBeenCalledWith("printf", ["hello world", "a|b", "space value", "trailing\\"], expect.any(Object))
+  })
+
+  it("rejects unterminated quotes before forwarding commands", async () => {
+    const exec = vi.fn(async () => ({ exitCode: 0, stderr: "", stdout: "" }))
+    const provider = createCloudflareShellProvider({
+      sandbox: { exec, supports: { execCwd: true, execEnv: true } },
+    })
+
+    await expect(provider.exec("cat 'unfinished")).rejects.toThrow("unterminated quote")
+    expect(exec).not.toHaveBeenCalled()
+  })
+
   it("delegates to the cloudflare sandbox client", async () => {
     const sandbox = {
       exec: vi.fn(async (_command: string, _args?: string[], options?: {
@@ -491,6 +512,16 @@ describe("@vite-hub/shell cloudflare runtime", () => {
 })
 
 describe("@vite-hub/shell analyzer", () => {
+  it.each([
+    ["echo 'a|b'", ["echo"], false],
+    ["echo a\\|b", ["echo"], false],
+    ["cat file | head", ["cat", "head"], true],
+    ["cat missing || echo fallback", ["cat", "echo"], true],
+    ["echo first && echo second; pwd", ["echo", "pwd"], false],
+  ] as const)("preserves command and pipeline metadata for %s", async (command, commands, hasPipelines) => {
+    await expect(analyzeShellCommand(command)).resolves.toMatchObject({ commands, hasPipelines, ok: true })
+  })
+
   it("parses shell commands with sh-syntax and returns conservative metadata", async () => {
     await expect(analyzeShellCommand("FOO=bar echo $(pwd) | tr a-z A-Z > out")).resolves.toMatchObject({
       commands: ["echo", "tr"],


### PR DESCRIPTION
Shell execution, command analysis and Workspace inspection duplicated quote/escape handling and command splitting. Share those helpers inside the Shell package and derive command names and pipeline flags from the same segments. This removes 105 net implementation lines.

Preserve execution's malformed-quote errors and trailing backslashes, inspection's tolerance of incomplete input, separator/pipeline metadata, and the existing sh-syntax parser and diagnostics. Public exports and emitted declarations are unchanged.

Validation:

- Full Shell suite: 29 tests passed, including seven new provider-forwarding and analyzer regressions.
- Before/after comparisons passed for 20,011 deterministic tokenizer, segment and Workspace inspection inputs, plus 20 public analyzer cases. Comparisons included errors, malformed quotes, escapes, separators, pipelines and incomplete commands.
- Package build, publint and typecheck passed. Emitted public declarations match the baseline byte for byte.
- Repository lint, TypeScript doctor and git diff --check passed.
- Cloudflare forwarding was checked with the client interface; no live provider run was needed for this shared parsing change.

Independent PR against main; it does not depend on #1374 or #1375.
