### PR TITLE
fix(ui): prevent raw HTML execution in agent Markdown

### DIFF
--- a/packages/ui/src/components/agent-markdown.ts
+++ b/packages/ui/src/components/agent-markdown.ts
@@ -40,7 +40,7 @@ export const AgentMarkdown = defineComponent({
         class: [defaults.markdown.class, attrs.class],
         components: { img: ImagePreview, math: AgentMath, ...props.components },
         plugins: [markdownMath, ...(props.plugins ?? []), ...(optionPlugins ?? [])],
-        options: { ...options, html: false, registerDefaultPlugins: false, streaming: props.streaming },
+        options: { ...options, html: false, streaming: props.streaming },
         value: props.value,
       });
     };

--- a/packages/ui/src/components/agent-markdown.ts
+++ b/packages/ui/src/components/agent-markdown.ts
@@ -40,7 +40,7 @@ export const AgentMarkdown = defineComponent({
         class: [defaults.markdown.class, attrs.class],
         components: { img: ImagePreview, math: AgentMath, ...props.components },
         plugins: [markdownMath, ...(props.plugins ?? []), ...(optionPlugins ?? [])],
-        options: { ...options, streaming: props.streaming },
+        options: { ...options, html: false, registerDefaultPlugins: false, streaming: props.streaming },
         value: props.value,
       });
     };

--- a/packages/ui/test/ssr.test.ts
+++ b/packages/ui/test/ssr.test.ts
@@ -56,6 +56,16 @@ describe("UI server rendering", () => {
     expect(html).toContain("message");
   });
 
+  it("preserves non-HTML Markdown defaults", async () => {
+    const app = createSSRApp({
+      render: () => h(AgentMarkdown, { value: "- [x] completed" }),
+    });
+
+    const html = await renderToString(app);
+    expect(html).toContain('type="checkbox"');
+    expect(html).toContain("completed");
+  });
+
   it("renders runtime Nuxt UI components through the Vue plugin", async () => {
     const app = createSSRApp({
       render: () =>

--- a/packages/ui/test/ssr.test.ts
+++ b/packages/ui/test/ssr.test.ts
@@ -43,6 +43,19 @@ describe("UI server rendering", () => {
     expect(html).toContain("katex");
   });
 
+  it("does not render raw HTML from Agent messages", async () => {
+    const app = createSSRApp({
+      render: () => h(AgentMarkdown, {
+        value: '<script>globalThis.__vitehubXss = true</script>\n\n<div onmouseover="globalThis.__vitehubXss = true">message</div>',
+      }),
+    });
+
+    const html = await renderToString(app);
+    expect(html).not.toContain("<script>");
+    expect(html).not.toContain('onmouseover="');
+    expect(html).toContain("message");
+  });
+
   it("renders runtime Nuxt UI components through the Vue plugin", async () => {
     const app = createSSRApp({
       render: () =>


### PR DESCRIPTION
## Problem
Agent message Markdown was rendered with raw HTML enabled. Untrusted assistant or user text could produce executable script/event-handler markup through `AgentMarkdown` and `AgentMessageParts`.

## Change
Disable raw HTML parsing in the shared AgentMarkdown renderer and add an SSR regression test covering script and event-handler input.

## Validation
- `pnpm --dir packages/ui exec vp test test/ssr.test.ts`
