### PR TITLE
fix(blob): protect filesystem metadata paths

### DIFF
--- a/packages/blob/src/drivers/fs.ts
+++ b/packages/blob/src/drivers/fs.ts
@@ -40,12 +40,13 @@ function resolveRoot(options: ResolvedFsBlobStoreConfig) {
 }
 
 function resolveBlobPath(root: string, pathname: string) {
-  if (pathname === ".vitehub" || pathname.startsWith(".vitehub/")) {
-    throw blobErrorDiagnostics.BLOB_R0005({ message: `Blob pathname uses a reserved internal path: ${pathname}` })
-  }
   const path = resolve(root, pathname)
   if (!isInside(root, path)) {
     throw blobErrorDiagnostics.BLOB_R0005({ message: `Blob pathname escapes the configured base: ${pathname}` })
+  }
+  const relativePath = relative(root, path)
+  if (relativePath === ".vitehub" || relativePath.startsWith(`.vitehub${sep}`)) {
+    throw blobErrorDiagnostics.BLOB_R0005({ message: `Blob pathname uses a reserved internal path: ${pathname}` })
   }
   return path
 }

--- a/packages/blob/src/drivers/fs.ts
+++ b/packages/blob/src/drivers/fs.ts
@@ -40,6 +40,9 @@ function resolveRoot(options: ResolvedFsBlobStoreConfig) {
 }
 
 function resolveBlobPath(root: string, pathname: string) {
+  if (pathname === ".vitehub" || pathname.startsWith(".vitehub/")) {
+    throw blobErrorDiagnostics.BLOB_R0005({ message: `Blob pathname uses a reserved internal path: ${pathname}` })
+  }
   const path = resolve(root, pathname)
   if (!isInside(root, path)) {
     throw blobErrorDiagnostics.BLOB_R0005({ message: `Blob pathname escapes the configured base: ${pathname}` })

--- a/packages/blob/src/drivers/fs.ts
+++ b/packages/blob/src/drivers/fs.ts
@@ -45,7 +45,8 @@ function resolveBlobPath(root: string, pathname: string) {
     throw blobErrorDiagnostics.BLOB_R0005({ message: `Blob pathname escapes the configured base: ${pathname}` })
   }
   const relativePath = relative(root, path)
-  if (relativePath === ".vitehub" || relativePath.startsWith(`.vitehub${sep}`)) {
+  const normalizedRelativePath = relativePath.toLowerCase()
+  if (normalizedRelativePath === ".vitehub" || normalizedRelativePath.startsWith(`.vitehub${sep}`)) {
     throw blobErrorDiagnostics.BLOB_R0005({ message: `Blob pathname uses a reserved internal path: ${pathname}` })
   }
   return path

--- a/packages/blob/test/fs.test.ts
+++ b/packages/blob/test/fs.test.ts
@@ -70,4 +70,13 @@ describe("fs blob driver", () => {
     expect(blob?.type).toBe("text/plain")
     expect(await blob?.text()).toBe("hello")
   })
+
+  it("rejects paths reserved for internal metadata", async () => {
+    const base = await mkdtemp(join(tmpdir(), "vitehub-blob-fs-"))
+    tempDirs.push(base)
+    const driver = createDriver({ base, driver: "fs" })
+
+    await expect(driver.put(".vitehub/blob-meta/poison.json", "{}"))
+      .rejects.toMatchObject({ code: "BLOB_R0005" })
+  })
 })

--- a/packages/blob/test/fs.test.ts
+++ b/packages/blob/test/fs.test.ts
@@ -80,5 +80,7 @@ describe("fs blob driver", () => {
       .rejects.toMatchObject({ code: "BLOB_R0005" })
     await expect(driver.put("nested/../.vitehub/blob-meta/poison.json", "{}"))
       .rejects.toMatchObject({ code: "BLOB_R0005" })
+    await expect(driver.put(".VITEHUB/blob-meta/poison.json", "{}"))
+      .rejects.toMatchObject({ code: "BLOB_R0005" })
   })
 })

--- a/packages/blob/test/fs.test.ts
+++ b/packages/blob/test/fs.test.ts
@@ -78,5 +78,7 @@ describe("fs blob driver", () => {
 
     await expect(driver.put(".vitehub/blob-meta/poison.json", "{}"))
       .rejects.toMatchObject({ code: "BLOB_R0005" })
+    await expect(driver.put("nested/../.vitehub/blob-meta/poison.json", "{}"))
+      .rejects.toMatchObject({ code: "BLOB_R0005" })
   })
 })


### PR DESCRIPTION
## Problem
The filesystem Blob driver stored metadata under `.vitehub/blob-meta`, but accepted user blob paths in that namespace. A caller could overwrite metadata with invalid JSON and make later reads and listings fail.

## Change
Reject all `.vitehub` paths at the filesystem driver boundary and add regression coverage.

## Validation
- `pnpm --dir packages/blob exec vp test test/fs.test.ts`
