### PR TITLE
fix(shell): reserve pending process slots

### DIFF
--- a/packages/shell/src/runtime/session.ts
+++ b/packages/shell/src/runtime/session.ts
@@ -97,7 +97,8 @@ class RuntimeShellSession implements ShellSession {
     if (!this.provider.startProcess || !this.boundary.processes.background) {
       throw shellErrorDiagnostics.SHELL_R0009({ message: "[vitehub] Shell provider does not support long-running processes." })
     }
-    if (typeof this.policy.maxProcesses === "number" && this.#processes.size + this.#starts.size >= this.policy.maxProcesses) {
+    const maxProcesses = this.policy.maxProcesses
+    if (maxProcesses !== undefined && this.#processes.size + this.#starts.size >= maxProcesses) {
       throw shellErrorDiagnostics.SHELL_R0010({ message: `[vitehub] Shell session process budget exhausted after ${this.policy.maxProcesses} processes.` })
     }
     let finishStart!: () => void

--- a/packages/shell/src/runtime/session.ts
+++ b/packages/shell/src/runtime/session.ts
@@ -97,7 +97,7 @@ class RuntimeShellSession implements ShellSession {
     if (!this.provider.startProcess || !this.boundary.processes.background) {
       throw shellErrorDiagnostics.SHELL_R0009({ message: "[vitehub] Shell provider does not support long-running processes." })
     }
-    if (typeof this.policy.maxProcesses === "number" && this.#processes.size >= this.policy.maxProcesses) {
+    if (typeof this.policy.maxProcesses === "number" && this.#processes.size + this.#starts.size >= this.policy.maxProcesses) {
       throw shellErrorDiagnostics.SHELL_R0010({ message: `[vitehub] Shell session process budget exhausted after ${this.policy.maxProcesses} processes.` })
     }
     let finishStart!: () => void

--- a/packages/shell/test/runtime.test.ts
+++ b/packages/shell/test/runtime.test.ts
@@ -167,6 +167,21 @@ describe("@vite-hub/shell just-bash runtime", () => {
     await expect(session.startProcess("three")).rejects.toThrow("Shell session is disposed")
   })
 
+  it("reserves process budget while starts are pending", async () => {
+    let release!: () => void
+    const gate = new Promise<void>(resolve => { release = resolve })
+    const provider = createBackgroundProvider(async (command: string): Promise<ShellProcess> => {
+      await gate
+      return { command, id: command, async stop() { return stoppedProcessObservation(command) } }
+    })
+    const session = createShellRuntime({ provider }).createSession({ policy: { maxProcesses: 1 } })
+    const first = session.startProcess("one")
+    await expect(session.startProcess("two")).rejects.toThrow("process budget exhausted after 1 processes")
+    release()
+    await expect(first).resolves.toMatchObject({ id: "one" })
+    await session.dispose()
+  })
+
   it("returns background-process cleanup failures without FiberFailure", async () => {
     const firstError = new Error("first stop failed")
     const secondError = new Error("second stop failed")


### PR DESCRIPTION
## Problem
Concurrent `startProcess` calls checked only already-registered processes, allowing a session with `maxProcesses: 1` to start multiple providers while the first start was pending.

## Change
Count pending process starts toward the session budget and add a concurrent regression test.

## Validation
- `pnpm --dir packages/shell exec vp test test/runtime.test.ts`
