### PR TITLE
fix(agent): satisfy strict doctor checks in channel sync

### DIFF
--- a/packages/agent/src/internal/channel-sync-cli.ts
+++ b/packages/agent/src/internal/channel-sync-cli.ts
@@ -260,15 +260,23 @@ export async function channelRegistration(
   }
   const registration = matching[0]!
   const secretToken = await resolvedChannelValue(registration.secretToken, context)
-  return {
+  const result: {
+    id: string
+    path?: string
+    secretHeader?: string
+    secretToken?: false | string
+    signature?: string
+    url?: string
+  } = {
     id: registration.id,
-    ...(registration.path ? { path: registration.path } : {}),
-    ...(registration.secretHeader ? { secretHeader: registration.secretHeader } : {}),
-    ...(secretToken === false || typeof secretToken === "string" ? { secretToken } : {}),
-    // doctor-disable-next-line typescript/strict/no-runtime-typeof -- CLI serialization accepts signature identifiers and omits executable verifier callbacks.
-    ...(typeof registration.signature === "string" ? { signature: registration.signature } : {}),
-    ...(registration.url ? { url: registration.url } : {}),
   }
+  if (registration.path) result.path = registration.path
+  if (registration.secretHeader) result.secretHeader = registration.secretHeader
+  if (secretToken === false || typeof secretToken === "string") result.secretToken = secretToken
+  // doctor-disable-next-line typescript/strict/no-runtime-typeof -- CLI serialization accepts signature identifiers and omits executable verifier callbacks.
+  if (typeof registration.signature === "string") result.signature = registration.signature
+  if (registration.url) result.url = registration.url
+  return result
 }
 
 function uniqueAgentDefinitions(


### PR DESCRIPTION
The CI type doctor rejects conditional empty-object spreads in channel webhook serialization when warnings are treated as errors.

This change builds the serialized registration object incrementally so optional fields are added only when present.

Validation: VITE_DOCTOR_SINCE=HEAD^1 pnpm exec vp run doctor:typescript; pnpm --dir packages/agent test