### PR TITLE
feat(agent): support preset definitions

### DIFF
--- a/packages/agent/src/agent-layers.ts
+++ b/packages/agent/src/agent-layers.ts
@@ -48,10 +48,17 @@ function merge(parent: unknown, child: unknown, path: string): unknown {
 
 /** Rebuild a definition from configuration. Never copy a parent's bound runtime or invocation state. */
 export function resolveAgentLayerOptions(input: unknown): unknown {
-  if (!record(input) || !("extends" in input)) return input
-  const { extends: parent, ...overrides } = input
+  if (!record(input)) return input
+  const hasExtends = "extends" in input
+  const hasPreset = "preset" in input
+  if (!hasExtends && !hasPreset) return input
+  if (hasExtends && hasPreset) {
+    throw new TypeError("[vitehub] defineAgent({ extends, preset }) accepts only one base definition.")
+  }
+  const parent = hasPreset ? input.preset : input.extends
+  const { extends: _extends, preset: _preset, ...overrides } = input
   if (!parent || !hasRuntimeType(parent, "object") || !layerOptions.has(parent)) {
-    throw new TypeError("[vitehub] defineAgent({ extends }) requires an Agent Definition created by defineAgent().")
+    throw new TypeError(`[vitehub] defineAgent({ ${hasPreset ? "preset" : "extends"} }) requires an Agent Definition created by defineAgent().`)
   }
   const { name: _parentName, ...defaults } = layerOptions.get(parent)!
   return merge(defaults, overrides, "")

--- a/packages/agent/src/index.ts
+++ b/packages/agent/src/index.ts
@@ -2117,6 +2117,21 @@ type AgentInvokerProfileOf<TOptions> = "invoker" extends keyof TOptions
   : AgentInvokerProfile
 
 export interface DefineAgent {
+  /** Derive an agent from a preset while optionally overriding its settings. */
+  <
+    TRuntimeConfig extends AgentRuntimeConfig = AgentRuntimeConfig,
+    CALL_OPTIONS = unknown,
+    const TInvokerProfile extends AgentInvokerProfile = AgentInvokerProfile,
+    TContextValues extends object = AgentInvocationContextValues,
+    TOutput = unknown,
+  >(
+    options: Omit<Partial<AgentSettings<TRuntimeConfig, CALL_OPTIONS, TInvokerProfile, TContextValues, AgentCapabilitiesInput<TRuntimeConfig>, TOutput>>, "driver" | "workspace"> & {
+      preset: AgentDefinition<TRuntimeConfig, CALL_OPTIONS, TInvokerProfile, TContextValues, TOutput>
+      driver?: Partial<AgentSettings<TRuntimeConfig, CALL_OPTIONS, TInvokerProfile, TContextValues, AgentCapabilitiesInput<TRuntimeConfig>, TOutput>["driver"]>
+      workspace?: WorkspaceAgentWorkspaceConfig
+    },
+  ): AgentDefinition<TRuntimeConfig, CALL_OPTIONS, TInvokerProfile, TContextValues, TOutput>
+
   <
     TRuntimeConfig extends AgentRuntimeConfig = AgentRuntimeConfig,
     CALL_OPTIONS = unknown,

--- a/packages/agent/src/types.ts
+++ b/packages/agent/src/types.ts
@@ -1554,6 +1554,8 @@ type AgentSharedSettings<
   invocations?: AgentInvocations
   messages?: AgentMessageChannelSettings<TRuntimeConfig>
   name?: string
+  /** Optional named workflow definition to use as the base configuration. */
+  preset?: AgentDefinition<TRuntimeConfig, CALL_OPTIONS, TInvokerProfile, TContextValues, TOutput>
   runtime?: AgentRuntimeBinding
   runEvents?: AgentRunEvents
   uiMessageStream?: AgentUIMessageStreamProjectionResolver<TRuntimeConfig, CALL_OPTIONS, TContextValues>

--- a/packages/agent/src/types.ts
+++ b/packages/agent/src/types.ts
@@ -1554,7 +1554,7 @@ type AgentSharedSettings<
   invocations?: AgentInvocations
   messages?: AgentMessageChannelSettings<TRuntimeConfig>
   name?: string
-  /** Optional named workflow definition to use as the base configuration. */
+  /** Agent definition to use as the base configuration. */
   preset?: AgentDefinition<TRuntimeConfig, CALL_OPTIONS, TInvokerProfile, TContextValues, TOutput>
   runtime?: AgentRuntimeBinding
   runEvents?: AgentRunEvents

--- a/packages/agent/test/agent-layers.test.ts
+++ b/packages/agent/test/agent-layers.test.ts
@@ -56,6 +56,23 @@ describe("Agent definition layers", () => {
     expect(third.resolve).not.toBe(base.resolve)
   })
 
+  it("uses preset as the public name for an inherited agent definition", () => {
+    const preset = defineAgent({
+      name: "preset",
+      driver: { kind: "codex", model: "base", reasoningEffort: "high" },
+      description: "preset defaults",
+      workspace: {},
+    })
+    const agent = defineAgent({ preset, driver: { model: "custom" } })
+    expect(agent.name).toBeUndefined()
+    expect(agent.description).toBe("preset defaults")
+    expect(agent.__vitehubWorkspaceAgentOptions.driver).toMatchObject({
+      kind: "codex",
+      model: "custom",
+      reasoningEffort: "high",
+    })
+  })
+
   it("replaces hooks by name and keeps other hooks", async () => {
     const parentInput = vi.fn()
     const childInput = vi.fn()
@@ -87,5 +104,8 @@ describe("Agent definition layers", () => {
 
   it("rejects arbitrary parents instead of copying a live agent runtime", () => {
     expect(() => defineAgent({ extends: {} as never })).toThrow("requires an Agent Definition")
+    expect(() => defineAgent({ preset: {} as never })).toThrow("requires an Agent Definition")
+    const base = defineAgent({ driver: "codex" })
+    expect(() => defineAgent({ extends: base, preset: base } as never)).toThrow("accepts only one base definition")
   })
 })


### PR DESCRIPTION
## What changed

Add `preset` as the public name for agent composition while reusing the existing `extends` layer resolver internally. Presets inherit the parent definition, keep existing merge semantics, and reject ambiguous `extends` plus `preset` configuration.

## Why

This gives applications and published agent packages a stable composition entry point without adding a second merge system or making the core agent package opinionated.

## Validation

- `corepack pnpm --dir packages/agent exec vitest run test/agent-layers.test.ts`
