### PR TITLE
feat(agent): resolve named preset extensions

### DIFF
--- a/docs/content/docs/agents/agent-definitions.md
+++ b/docs/content/docs/agents/agent-definitions.md
@@ -90,6 +90,27 @@ Child configuration overrides parent defaults. Channels, Sources, Skills, and ho
 
 `extends` accepts one definition created by `defineAgent()` in the same package instance. It does not discover files in the parent's directory. Import shared instructions with `@../bot/instructions.md` and share Skills through explicit Sources or a directory link. Relative file paths resolve from each discovered Agent's directory.
 
+### Named presets
+
+Export ordinary `defineAgent()` definitions from a preset package. Consumers import them and select a local name:
+
+```ts
+import { defineAgent } from "@vite-hub/agent"
+import { notetaker } from "@example/agents"
+
+export default defineAgent({
+  preset: "notetaker",
+  presets: { notetaker },
+  name: "meeting-notes",
+  driver: { model: "gpt-5.6-sol" },
+})
+```
+
+`preset` must name an own entry in `presets`. Selection uses the same composition as `extends`, including child overrides and a fresh runtime. Specify one parent with either `preset` or `extends`. The map belongs to this definition; it does not register global names or load packages. Neither the map nor its selected name becomes model instructions.
+
+Preset packages must declare `@vite-hub/agent` as a peer dependency so their definitions share the application's package instance. Export configured Agents directly, or expose a small typed configuration function that returns a `defineAgent()` definition. Package authors must include instruction content and required assets explicitly; selecting a preset does not discover its package directory.
+
+
 ## Return structured output
 
 Set `driver.output` when downstream code needs validated data instead of free-form text.

--- a/packages/agent/README.md
+++ b/packages/agent/README.md
@@ -345,6 +345,27 @@ Child configuration overrides parent defaults. Channels, Sources, Skills, and ho
 
 `extends` accepts one definition created by `defineAgent()` in the same package instance. It does not discover files in the parent's directory. Import shared instructions with `@../bot/instructions.md` and share Skills through explicit Sources or a directory link. Relative file paths resolve from each discovered Agent's directory.
 
+### Named presets
+
+Export ordinary `defineAgent()` definitions from a preset package. Consumers import them and select a local name:
+
+```ts
+import { defineAgent } from "@vite-hub/agent"
+import { notetaker } from "@example/agents"
+
+export default defineAgent({
+  preset: "notetaker",
+  presets: { notetaker },
+  name: "meeting-notes",
+  driver: { model: "gpt-5.6-sol" },
+})
+```
+
+`preset` must name an own entry in `presets`. Selection uses the same composition as `extends`, including child overrides and a fresh runtime. Specify one parent with either `preset` or `extends`. The map belongs to this definition; it does not register global names or load packages. Neither the map nor its selected name becomes model instructions.
+
+Preset packages must declare `@vite-hub/agent` as a peer dependency so their definitions share the application's package instance. Export configured Agents directly, or expose a small typed configuration function that returns a `defineAgent()` definition. Package authors must include instruction content and required assets explicitly; selecting a preset does not discover its package directory.
+
+
 
 ## evlog integration
 

--- a/packages/agent/src/agent-layers.ts
+++ b/packages/agent/src/agent-layers.ts
@@ -1,4 +1,5 @@
 import { hasRuntimeType } from "./internal/runtime-type.ts"
+import { resolveNamedAgentPresetOptions } from "./agent-presets.ts"
 import type { AgentDefinition, AgentSettings } from "./types.ts"
 
 const layerOptions = new WeakMap<object, Record<string, unknown>>()
@@ -48,6 +49,7 @@ function merge(parent: unknown, child: unknown, path: string): unknown {
 
 /** Rebuild a definition from configuration. Never copy a parent's bound runtime or invocation state. */
 export function resolveAgentLayerOptions(input: unknown): unknown {
+  input = resolveNamedAgentPresetOptions(input)
   if (!record(input) || !("extends" in input)) return input
   const { extends: parent, ...overrides } = input
   if (!parent || !hasRuntimeType(parent, "object") || !layerOptions.has(parent)) {

--- a/packages/agent/src/agent-presets.ts
+++ b/packages/agent/src/agent-presets.ts
@@ -1,0 +1,18 @@
+import { hasRuntimeType, isRuntimeRecord } from "./internal/runtime-type.ts"
+
+/** Resolve a local name before the normal Agent layer composition. */
+export function resolveNamedAgentPresetOptions(input: unknown): unknown {
+  if (!isRuntimeRecord(input)) return input
+  if (!("presets" in input) && !hasRuntimeType(input.preset, "string")) return input
+  const { preset, presets, ...options } = input
+  if ("extends" in options) {
+    throw new TypeError("[vitehub] Select one Agent parent with preset or extends, not both.")
+  }
+  if (!hasRuntimeType(preset, "string") || !preset.trim()) {
+    throw new TypeError("[vitehub] defineAgent({ presets }) requires a non-empty preset name.")
+  }
+  if (!presets || !hasRuntimeType(presets, "object") || Array.isArray(presets) || !Object.hasOwn(presets, preset)) {
+    throw new TypeError(`[vitehub] Agent preset "${preset}" is not defined in presets.`)
+  }
+  return { ...options, extends: Reflect.get(presets, preset) }
+}

--- a/packages/agent/src/agent-presets.ts
+++ b/packages/agent/src/agent-presets.ts
@@ -3,7 +3,7 @@ import { hasRuntimeType, isRuntimeRecord } from "./internal/runtime-type.ts"
 /** Resolve a local name before the normal Agent layer composition. */
 export function resolveNamedAgentPresetOptions(input: unknown): unknown {
   if (!isRuntimeRecord(input)) return input
-  if (!("presets" in input) && !hasRuntimeType(input.preset, "string")) return input
+  if (!("presets" in input) && !("preset" in input)) return input
   const { preset, presets, ...options } = input
   if ("extends" in options) {
     throw new TypeError("[vitehub] Select one Agent parent with preset or extends, not both.")

--- a/packages/agent/src/discovery.ts
+++ b/packages/agent/src/discovery.ts
@@ -87,8 +87,17 @@ function isWorkspaceAgentDefinition(source: string): boolean {
   for (let i = 0; i < tokens.length; i++) {
     if (depth === 0) {
       if (tokens[i] === "import") {
-        for (let j = i + 1; j < tokens.length && tokens[j] !== ";"; j++) {
-          if (/^[A-Za-z_$]/.test(tokens[j]) && !["from", "as", "type"].includes(tokens[j])) imported.add(tokens[j])
+        // Imports are often semicolonless; stop at the module specifier rather
+        // than consuming identifiers from following declarations.
+        let sawFrom = false
+        for (let j = i + 1; j < tokens.length; j++) {
+          const token = tokens[j]
+          if (token === "from") { sawFrom = true; continue }
+          if (sawFrom) {
+            if (/^["'`]/.test(token)) break
+            continue
+          }
+          if (/^[A-Za-z_$]/.test(token) && !["from", "as", "type"].includes(token)) imported.add(token)
         }
       }
       if (["const", "let", "var"].includes(tokens[i])) {

--- a/packages/agent/src/discovery.ts
+++ b/packages/agent/src/discovery.ts
@@ -93,24 +93,13 @@ function isWorkspaceAgentDefinition(source: string): boolean {
     if (/^\s*presets\s*:/.test(rest) || /^\s*presets\s*,/.test(rest)) hasPresets = true
   }
   if (!hasPreset || !hasPresets) return false
-  // Inline preset registries can own a Workspace even when the outer options do not.
-  // Restrict this check to the top-level `presets` property value and inspect each
-  // inline defineAgent options object for its own top-level workspace declaration.
-  const presetsMatch = stripped.match(/\bpresets\s*:\s*\{/)
-  if (!presetsMatch || presetsMatch.index === undefined) return false
-  let registryDepth = 1
-  for (let i = presetsMatch.index + presetsMatch[0].length; i < stripped.length; i++) {
-    const char = stripped[i]
-    if (char === "{") registryDepth++
-    else if (char === "}") {
-      registryDepth--
-      if (registryDepth === 0) break
-    }
-    if (registryDepth !== 1) continue
-    const rest = stripped.slice(i)
-    const inline = rest.match(/defineAgent\s*\(\s*\{([\s\S]*?)\}\s*\)/)
-    if (inline && /(?:^|[,{])\s*workspace\s*:/.test(inline[1])) return true
-  }
+  // Inline preset registries can own a Workspace; inspect only the selected entry.
+  const presetValue = stripped.slice(call.index + call[0].length, stripped.length).match(/(?:^|[,{}])\s*preset\s*:\s*["']([^"']+)["']/)?.[1]
+  const presetsMatch = stripped.match(/(?:^|[,{}])\s*presets\s*:\s*\{/ )
+  if (!presetValue || !presetsMatch || presetsMatch.index === undefined) return false
+  const registryStart = presetsMatch.index + presetsMatch[0].length
+  const selected = stripped.slice(registryStart).match(new RegExp(`(?:^|[,{}])\\s*${presetValue.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")}\\s*:\\s*defineAgent\\s*\\(\\s*\\{([\\s\\S]*?)\\}\\s*\\)`))
+  return !!selected && /(?:^|[,{])\s*workspace\s*:/.test(selected[1])
   return false
 }
 

--- a/packages/agent/src/discovery.ts
+++ b/packages/agent/src/discovery.ts
@@ -144,8 +144,18 @@ function isWorkspaceAgentDefinition(source: string): boolean {
     while (tokens[index] === "(") index++
     if (seen.has(index)) return false
     seen.add(index)
-    if (tokens[index] !== "defineAgent" || tokens[index + 1] !== "(") return false
-    const options = properties(index + 2)
+    if (tokens[index] !== "defineAgent") return false
+    let call = index + 1
+    if (tokens[call] === "<") {
+      let genericDepth = 0
+      do {
+        if (tokens[call] === "<") genericDepth++
+        if (tokens[call] === ">") genericDepth--
+        call++
+      } while (call < tokens.length && genericDepth > 0)
+    }
+    if (tokens[call] !== "(") return false
+    const options = properties(call + 1)
     const workspace = options.get("workspace")
     if (workspace !== undefined) {
       const value = resolveReference(workspace)
@@ -158,6 +168,7 @@ function isWorkspaceAgentDefinition(source: string): boolean {
         return true
       }
       if (tokens[value] === "defineWorkspace") return true
+      if (/^["'`]/.test(tokens[value] ?? "")) return false
     }
     const preset = options.get("preset")
     const registry = options.get("presets")

--- a/packages/agent/src/discovery.ts
+++ b/packages/agent/src/discovery.ts
@@ -74,10 +74,19 @@ function stripComments(source: string) {
 
 function isWorkspaceAgentDefinition(source: string): boolean {
   const stripped = stripComments(source)
-  // Workspace ownership may come from an inline override or from a named preset
-  // declared in the same module. Require an explicit workspace property somewhere
-  // in the module so ordinary preset selections remain ordinary Agents.
-  return /\bworkspace\s*(?::|[,}])/.test(stripped)
+  const call = stripped.match(/\bdefineAgent\s*\(\s*\{/)
+  if (!call || call.index === undefined) return false
+  let depth = 1
+  for (let i = call.index + call[0].length; i < stripped.length; i++) {
+    const char = stripped[i]
+    if (char === "{") depth++
+    else if (char === "}") {
+      depth--
+      if (depth === 0) break
+    }
+    if (depth === 1 && /\bworkspace\s*:/.test(stripped.slice(i))) return true
+  }
+  return false
 }
 
 function isAgentDefinitionSource(source: string): boolean {

--- a/packages/agent/src/discovery.ts
+++ b/packages/agent/src/discovery.ts
@@ -74,10 +74,10 @@ function stripComments(source: string) {
 
 function isWorkspaceAgentDefinition(source: string): boolean {
   const stripped = stripComments(source)
-  // A preset selection alone does not imply Workspace ownership. Classify inline
-  // preset definitions only when the source also contains a workspace property;
-  // this avoids registering ordinary presets as hosted Workspaces.
-  return /\bdefineAgent\s*\(\s*\{[\s\S]*\bworkspace\s*(?::|[,}])/.test(stripped)
+  // Workspace ownership may come from an inline override or from a named preset
+  // declared in the same module. Require an explicit workspace property somewhere
+  // in the module so ordinary preset selections remain ordinary Agents.
+  return /\bworkspace\s*(?::|[,}])/.test(stripped)
 }
 
 function isAgentDefinitionSource(source: string): boolean {

--- a/packages/agent/src/discovery.ts
+++ b/packages/agent/src/discovery.ts
@@ -93,6 +93,7 @@ function isWorkspaceAgentDefinition(source: string): boolean {
         for (let j = i + 1; j < tokens.length; j++) {
           const token = tokens[j]
           if (token === "from") { sawFrom = true; continue }
+          if (!sawFrom && /^['"`]/.test(token)) break
           if (sawFrom) {
             if (/^["'`]/.test(token)) break
             continue
@@ -191,8 +192,10 @@ function isWorkspaceAgentDefinition(source: string): boolean {
       // An explicit Workspace value (including a string reference or an
       // unresolved imported binding) overrides any preset Workspace. Do not
       // fall through to preset lookup when the child supplied `workspace`.
-      return false
+      return true
     }
+    const inherited = options.get("extends")
+    if (inherited !== undefined && ownsWorkspace(inherited, seen)) return true
     const preset = options.get("preset")
     const registry = options.get("presets")
     if (preset === undefined || registry === undefined) return false

--- a/packages/agent/src/discovery.ts
+++ b/packages/agent/src/discovery.ts
@@ -172,10 +172,17 @@ function isWorkspaceAgentDefinition(source: string): boolean {
             close++
           }
           if (bracketDepth === 0 && tokens[close] === ":") {
-            const keyToken = tokens[i + 1]
-            const keyValue = resolveReference(i + 1)
-            const key = propertyName(tokens[keyValue] ?? keyToken)
-            result.set(key, close + 1)
+            const expression = tokens.slice(i + 1, close - 1)
+            let key: string | undefined
+            const literalParts: string[] = []
+            for (let p = 0; p < expression.length; p += 2) {
+              const part = expression[p]
+              if (!part || !/^["'`]/.test(part)) { key = undefined; break }
+              literalParts.push(propertyName(part))
+              if (p + 1 < expression.length && expression[p + 1] !== "+") { key = undefined; break }
+            }
+            if (literalParts.length) key = literalParts.join("")
+            if (key !== undefined) result.set(key, close + 1)
             i = close
             atProperty = false
           }
@@ -195,7 +202,10 @@ function isWorkspaceAgentDefinition(source: string): boolean {
     while (tokens[index] === "(") index++
     if (seen.has(index)) return false
     seen.add(index)
-    if (tokens[index] !== "defineAgent") return false
+    if (tokens[index] !== "defineAgent") {
+      if (!(tokens[index + 1] === "." && tokens[index + 2] === "defineAgent")) return false
+      index += 2
+    }
     let call = index + 1
     if (tokens[call] === "<") {
       let genericDepth = 0

--- a/packages/agent/src/discovery.ts
+++ b/packages/agent/src/discovery.ts
@@ -81,10 +81,16 @@ function tokenizeAgentSource(source: string): string[] {
 function isWorkspaceAgentDefinition(source: string): boolean {
   const tokens = tokenizeAgentSource(source)
   const declarations = new Map<string, number>()
+  const imported = new Set<string>()
   let exported: number | undefined
   let depth = 0
   for (let i = 0; i < tokens.length; i++) {
     if (depth === 0) {
+      if (tokens[i] === "import") {
+        for (let j = i + 1; j < tokens.length && tokens[j] !== ";"; j++) {
+          if (/^[A-Za-z_$]/.test(tokens[j]) && !["from", "as", "type"].includes(tokens[j])) imported.add(tokens[j])
+        }
+      }
       if (["const", "let", "var"].includes(tokens[i])) {
         const name = tokens[i + 1]
         let equals = i + 2
@@ -168,6 +174,7 @@ function isWorkspaceAgentDefinition(source: string): boolean {
         return true
       }
       if (tokens[value] === "defineWorkspace") return true
+      if (imported.has(tokens[value])) return true
       if (/^["'`]/.test(tokens[value] ?? "")) return false
     }
     const preset = options.get("preset")

--- a/packages/agent/src/discovery.ts
+++ b/packages/agent/src/discovery.ts
@@ -160,6 +160,10 @@ function isWorkspaceAgentDefinition(source: string): boolean {
           for (const [key, value] of spread) result.set(key, value)
           i += 2
           atProperty = false
+        } else if (token === "[" && tokens[i + 2] === "]" && tokens[i + 3] === ":") {
+          const key = propertyName(tokens[i + 1])
+          result.set(key, i + 4)
+          i += 3
         } else if (tokens[i + 1] === ":") result.set(propertyName(token), i + 2)
         else if ([",", "}"].includes(tokens[i + 1])) result.set(propertyName(token), i)
         atProperty = false

--- a/packages/agent/src/discovery.ts
+++ b/packages/agent/src/discovery.ts
@@ -109,9 +109,9 @@ function isWorkspaceAgentDefinition(source: string): boolean {
         for (let j = i + 1; j < tokens.length; j++) {
           const token = tokens[j]
           if (token === "from") { sawFrom = true; continue }
-          if (!sawFrom && /^['"`]/.test(token)) break
+          if (!sawFrom && /^['"`]/.test(token)) { i = j; break }
           if (sawFrom) {
-            if (/^["'`]/.test(token)) break
+            if (/^["'`]/.test(token)) { i = j; break }
             continue
           }
           if (/^[A-Za-z_$]/.test(token) && !["from", "as", "type"].includes(token)) imported.add(token)

--- a/packages/agent/src/discovery.ts
+++ b/packages/agent/src/discovery.ts
@@ -172,7 +172,7 @@ function isWorkspaceAgentDefinition(source: string): boolean {
             close++
           }
           if (bracketDepth === 0 && tokens[close] === ":") {
-            const expression = tokens.slice(i + 1, close - 1)
+            const expression = tokens.slice(i + 1, close - 1).filter(token => token !== "(" && token !== ")")
             let key: string | undefined
             const literalParts: string[] = []
             for (let p = 0; p < expression.length; p += 2) {

--- a/packages/agent/src/discovery.ts
+++ b/packages/agent/src/discovery.ts
@@ -143,7 +143,14 @@ function isWorkspaceAgentDefinition(source: string): boolean {
     const workspace = options.get("workspace")
     if (workspace !== undefined) {
       const value = resolveReference(workspace)
-      if (tokens[value] === "{") return true
+      if (tokens[value] === "{") {
+        // A `{ name: "shared" }` value is a Workspace reference, not an
+        // owned Workspace definition. Runtime applies the same distinction.
+        const workspaceProperties = properties(value)
+        const name = workspaceProperties.get("name")
+        if (name !== undefined && /^(["\'`])/.test(tokens[resolveReference(name)] ?? "")) return false
+        return true
+      }
       if (tokens[value] === "defineWorkspace") return true
     }
     const preset = options.get("preset")

--- a/packages/agent/src/discovery.ts
+++ b/packages/agent/src/discovery.ts
@@ -85,8 +85,11 @@ function isWorkspaceAgentDefinition(source: string): boolean {
   let depth = 0
   for (let i = 0; i < tokens.length; i++) {
     if (depth === 0) {
-      if (["const", "let", "var"].includes(tokens[i]) && tokens[i + 2] === "=") {
-        declarations.set(tokens[i + 1], i + 3)
+      if (["const", "let", "var"].includes(tokens[i])) {
+        const name = tokens[i + 1]
+        let equals = i + 2
+        while (equals < tokens.length && tokens[equals] !== "=" && tokens[equals] !== ";") equals++
+        if (name && tokens[equals] === "=") declarations.set(name, equals + 1)
       }
       if (tokens[i] === "export" && tokens[i + 1] === "default") exported = i + 2
       if (tokens[i] === "export" && tokens[i + 1] === "{" ) {

--- a/packages/agent/src/discovery.ts
+++ b/packages/agent/src/discovery.ts
@@ -176,6 +176,10 @@ function isWorkspaceAgentDefinition(source: string): boolean {
       if (tokens[value] === "defineWorkspace") return true
       if (imported.has(tokens[value])) return true
       if (/^["'`]/.test(tokens[value] ?? "")) return false
+      // An explicit Workspace value (including a string reference or an
+      // unresolved imported binding) overrides any preset Workspace. Do not
+      // fall through to preset lookup when the child supplied `workspace`.
+      return false
     }
     const preset = options.get("preset")
     const registry = options.get("presets")

--- a/packages/agent/src/discovery.ts
+++ b/packages/agent/src/discovery.ts
@@ -82,6 +82,7 @@ function isWorkspaceAgentDefinition(source: string): boolean {
   const tokens = tokenizeAgentSource(source)
   const declarations = new Map<string, number>()
   const imported = new Set<string>()
+  const importedNamespaces = new Set<string>()
   let exported: number | undefined
   let depth = 0
   for (let i = 0; i < tokens.length; i++) {
@@ -106,9 +107,14 @@ function isWorkspaceAgentDefinition(source: string): boolean {
         // Imports are often semicolonless; stop at the module specifier rather
         // than consuming identifiers from following declarations.
         let sawFrom = false
+        let sawStar = false
         for (let j = i + 1; j < tokens.length; j++) {
           const token = tokens[j]
           if (token === "from") { sawFrom = true; continue }
+          if (!sawFrom && token === "*") { sawStar = true; continue }
+          if (!sawFrom && sawStar && token === "as" && tokens[j + 1]) {
+            importedNamespaces.add(tokens[j + 1]); continue
+          }
           if (!sawFrom && /^['"`]/.test(token)) { i = j; break }
           if (sawFrom) {
             if (/^["'`]/.test(token)) { i = j; break }
@@ -208,7 +214,7 @@ function isWorkspaceAgentDefinition(source: string): boolean {
     if (seen.has(index)) return false
     seen.add(index)
     if (tokens[index] !== "defineAgent") {
-      if (!(tokens[index + 1] === "." && tokens[index + 2] === "defineAgent")) return false
+      if (!(tokens[index + 1] === "." && tokens[index + 2] === "defineAgent" && importedNamespaces.has(tokens[index]))) return false
       index += 2
     }
     let call = index + 1

--- a/packages/agent/src/discovery.ts
+++ b/packages/agent/src/discovery.ts
@@ -161,7 +161,9 @@ function isWorkspaceAgentDefinition(source: string): boolean {
           i += 2
           atProperty = false
         } else if (token === "[" && tokens[i + 2] === "]" && tokens[i + 3] === ":") {
-          const key = propertyName(tokens[i + 1])
+          const keyToken = tokens[i + 1]
+          const keyValue = resolveReference(i + 1)
+          const key = propertyName(tokens[keyValue] ?? keyToken)
           result.set(key, i + 4)
           i += 3
         } else if (tokens[i + 1] === ":") result.set(propertyName(token), i + 2)

--- a/packages/agent/src/discovery.ts
+++ b/packages/agent/src/discovery.ts
@@ -174,6 +174,9 @@ function isWorkspaceAgentDefinition(source: string): boolean {
         return true
       }
       if (tokens[value] === "defineWorkspace") return true
+      // Imported Workspace configurations cannot be resolved to a local
+      // declaration, but they are valid runtime values and therefore imply
+      // that this Agent owns a Workspace.
       if (imported.has(tokens[value])) return true
       if (/^["'`]/.test(tokens[value] ?? "")) return false
       // An explicit Workspace value (including a string reference or an

--- a/packages/agent/src/discovery.ts
+++ b/packages/agent/src/discovery.ts
@@ -113,7 +113,11 @@ function isWorkspaceAgentDefinition(source: string): boolean {
           if (token === "from") { sawFrom = true; continue }
           if (!sawFrom && token === "*") { sawStar = true; continue }
           if (!sawFrom && sawStar && token === "as" && tokens[j + 1]) {
-            importedNamespaces.add(tokens[j + 1]); continue
+            // Record namespace bindings only for the Agent package import.
+            // Local objects may expose a similarly named method.
+            const moduleToken = tokens.slice(j + 2).find(candidate => /^['"`]/.test(candidate))
+            if (moduleToken && /vite-hub(?:\/agent)?/.test(moduleToken)) importedNamespaces.add(tokens[j + 1])
+            continue
           }
           if (!sawFrom && /^['"`]/.test(token)) { i = j; break }
           if (sawFrom) {

--- a/packages/agent/src/discovery.ts
+++ b/packages/agent/src/discovery.ts
@@ -102,6 +102,7 @@ function isWorkspaceAgentDefinition(source: string): boolean {
   }
 
   function resolveReference(index: number, seen = new Set<number>()): number {
+    while (tokens[index] === "(") index++
     if (seen.has(index)) return index
     seen.add(index)
     const reference = declarations.get(tokens[index])
@@ -122,7 +123,12 @@ function isWorkspaceAgentDefinition(source: string): boolean {
       const token = tokens[i]
       if (depth === 0 && token === "}") break
       if (depth === 0 && atProperty) {
-        if (tokens[i + 1] === ":") result.set(propertyName(token), i + 2)
+        if (token === "." && tokens[i + 1] === "." && tokens[i + 2] === ".") {
+          const spread = properties(i + 3)
+          for (const [key, value] of spread) result.set(key, value)
+          i += 2
+          atProperty = false
+        } else if (tokens[i + 1] === ":") result.set(propertyName(token), i + 2)
         else if ([",", "}"].includes(tokens[i + 1])) result.set(propertyName(token), i)
         atProperty = false
       }

--- a/packages/agent/src/discovery.ts
+++ b/packages/agent/src/discovery.ts
@@ -77,7 +77,7 @@ function isWorkspaceAgentDefinition(source: string): boolean {
   // A preset selection alone does not imply Workspace ownership. Classify inline
   // preset definitions only when the source also contains a workspace property;
   // this avoids registering ordinary presets as hosted Workspaces.
-  return /\bdefineAgent\s*\(\s*\{[\s\S]*\bworkspace\s*:/.test(stripped)
+  return /\bdefineAgent\s*\(\s*\{[\s\S]*\bworkspace\s*(?::|[,}])/.test(stripped)
 }
 
 function isAgentDefinitionSource(source: string): boolean {

--- a/packages/agent/src/discovery.ts
+++ b/packages/agent/src/discovery.ts
@@ -160,12 +160,25 @@ function isWorkspaceAgentDefinition(source: string): boolean {
           for (const [key, value] of spread) result.set(key, value)
           i += 2
           atProperty = false
-        } else if (token === "[" && tokens[i + 2] === "]" && tokens[i + 3] === ":") {
-          const keyToken = tokens[i + 1]
-          const keyValue = resolveReference(i + 1)
-          const key = propertyName(tokens[keyValue] ?? keyToken)
-          result.set(key, i + 4)
-          i += 3
+        } else if (token === "[") {
+          // Computed keys may reference a statically-resolvable identifier.
+          // Locate the matching bracket rather than assuming a fixed token
+          // layout (parentheses and other expressions are valid here).
+          let close = i + 1
+          let bracketDepth = 1
+          while (close < tokens.length && bracketDepth > 0) {
+            if (tokens[close] === "[") bracketDepth++
+            else if (tokens[close] === "]") bracketDepth--
+            close++
+          }
+          if (bracketDepth === 0 && tokens[close] === ":") {
+            const keyToken = tokens[i + 1]
+            const keyValue = resolveReference(i + 1)
+            const key = propertyName(tokens[keyValue] ?? keyToken)
+            result.set(key, close + 1)
+            i = close
+            atProperty = false
+          }
         } else if (tokens[i + 1] === ":") result.set(propertyName(token), i + 2)
         else if ([",", "}"].includes(tokens[i + 1])) result.set(propertyName(token), i)
         atProperty = false

--- a/packages/agent/src/discovery.ts
+++ b/packages/agent/src/discovery.ts
@@ -87,6 +87,10 @@ function isWorkspaceAgentDefinition(source: string): boolean {
   for (let i = 0; i < tokens.length; i++) {
     if (depth === 0) {
       if (tokens[i] === "import") {
+        // Dynamic imports are expressions, not static declarations. Ignore
+        // them entirely so identifiers in the surrounding module cannot be
+        // mistaken for imported Workspace bindings.
+        if (tokens[i + 1] === "(") continue
         // Imports are often semicolonless; stop at the module specifier rather
         // than consuming identifiers from following declarations.
         let sawFrom = false

--- a/packages/agent/src/discovery.ts
+++ b/packages/agent/src/discovery.ts
@@ -115,8 +115,14 @@ function isWorkspaceAgentDefinition(source: string): boolean {
           if (!sawFrom && sawStar && token === "as" && tokens[j + 1]) {
             // Record namespace bindings only for the Agent package import.
             // Local objects may expose a similarly named method.
-            const moduleToken = tokens.slice(j + 2).find(candidate => /^['"`]/.test(candidate))
-            if (moduleToken && /vite-hub(?:\/agent)?/.test(moduleToken)) importedNamespaces.add(tokens[j + 1])
+            const moduleIndex = tokens.indexOf("from", j + 2)
+            const moduleToken = moduleIndex >= 0
+              ? tokens[moduleIndex + 1]
+              : tokens.slice(j + 2).find(candidate => /^['"`]/.test(candidate))
+            const moduleName = moduleToken?.slice(1, -1)
+            if (moduleName === "@vite-hub/agent" || moduleName === "vite-hub/agent") {
+              importedNamespaces.add(tokens[j + 1])
+            }
             continue
           }
           if (!sawFrom && /^['"`]/.test(token)) { i = j; break }

--- a/packages/agent/src/discovery.ts
+++ b/packages/agent/src/discovery.ts
@@ -88,7 +88,7 @@ function isWorkspaceAgentDefinition(source: string): boolean {
       if (["const", "let", "var"].includes(tokens[i])) {
         const name = tokens[i + 1]
         let equals = i + 2
-        while (equals < tokens.length && tokens[equals] !== "=" && tokens[equals] !== ";") equals++
+        while (equals < tokens.length && tokens[equals] !== "=" && tokens[equals] !== ";" && tokens[equals] !== ",") equals++
         if (name && tokens[equals] === "=") declarations.set(name, equals + 1)
       }
       if (tokens[i] === "export" && tokens[i + 1] === "default") exported = i + 2

--- a/packages/agent/src/discovery.ts
+++ b/packages/agent/src/discovery.ts
@@ -72,33 +72,79 @@ function stripComments(source: string) {
     .replace(/(^|[^:])\/\/.*$/gm, "$1")
 }
 
+// Keep literals as single tokens so their punctuation cannot change object depth.
+function tokenizeAgentSource(source: string): string[] {
+  return source.match(/"(?:\\.|[^"\\])*"|'(?:\\.|[^'\\])*'|`(?:\\.|[^`\\])*`|\/\*[\s\S]*?\*\/|\/\/[^\n]*|\/(?:\\.|\[(?:\\.|[^\]\\])*\]|[^/\n\\])+\/[dgimsuvy]*|[A-Za-z_$][\w$]*|[^\s]/g)
+    ?.filter(token => !token.startsWith("//") && !token.startsWith("/*")) ?? []
+}
+
 function isWorkspaceAgentDefinition(source: string): boolean {
-  const stripped = stripComments(source)
-  const call = stripped.match(/\bdefineAgent\s*\(\s*\{/)
-  if (!call || call.index === undefined) return false
-  const options = stripped.slice(call.index + call[0].length)
-  let depth = 1; let hasWorkspace = false; let presetExpr: string | undefined; let hasPresets = false
-  for (let i = 0; i < options.length; i++) {
-    const c = options[i]
-    if (c === "{") depth++
-    else if (c === "}") { depth--; if (depth === 0) break }
-    if (depth !== 1) continue
-    const rest = options.slice(i)
-    if (/^\s*workspace\s*:/.test(rest)) hasWorkspace = true
-    const m = rest.match(/^\s*preset\s*:\s*([^,}\n]+)/)
-    if (m) presetExpr = m[1].trim()
-    if (/^\s*preset\s*,/.test(rest)) presetExpr = "preset"
-    if (/^\s*presets\s*(?::|,)/.test(rest)) hasPresets = true
+  const tokens = tokenizeAgentSource(source)
+  const declarations = new Map<string, number>()
+  let exported: number | undefined
+  let depth = 0
+  for (let i = 0; i < tokens.length; i++) {
+    if (depth === 0) {
+      if (["const", "let", "var"].includes(tokens[i]) && tokens[i + 2] === "=") {
+        declarations.set(tokens[i + 1], i + 3)
+      }
+      if (tokens[i] === "export" && tokens[i + 1] === "default") exported = i + 2
+    }
+    if (["{", "(", "["].includes(tokens[i])) depth++
+    if (["}", ")", "]"].includes(tokens[i])) depth--
   }
-  if (hasWorkspace || !presetExpr || !hasPresets) return hasWorkspace
-  const name = presetExpr.match(/^['"]([^'"]+)['"]$/)?.[1] ?? stripped.match(new RegExp(`(?:const|let|var)\\s+${presetExpr}\\s*=\\s*['"]([^'"]+)['"]`))?.[1]
-  if (!name) return false
-  const e = name.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")
-  const entry = stripped.match(new RegExp(`${e}\\s*:\\s*(defineAgent\\s*\\(\\s*\\{[\\s\\S]*?\\}\\)|[A-Za-z_$][\\w$]*)`))?.[1] ?? (stripped.match(new RegExp(`(?:[,{]\\s*)${e}\\s*(?=[,}])`)) ? name : undefined)
-  if (!entry) return false
-  if (/workspace\s*:/.test(entry)) return true
-  const ref = entry.match(/^([A-Za-z_$][\w$]*)$/)?.[1]
-  return !!ref && !!stripped.match(new RegExp(`(?:const|let|var)\\s+${ref}\\s*=\\s*defineAgent\\s*\\(\\s*\\{[\\s\\S]*?workspace\\s*:`))
+
+  function resolveReference(index: number, seen = new Set<number>()): number {
+    if (seen.has(index)) return index
+    seen.add(index)
+    const reference = declarations.get(tokens[index])
+    return reference === undefined ? index : resolveReference(reference, seen)
+  }
+
+  function propertyName(token: string): string {
+    return /^["'`]/.test(token) ? token.slice(1, -1) : token
+  }
+
+  function properties(index: number): Map<string, number> {
+    const result = new Map<string, number>()
+    index = resolveReference(index)
+    if (tokens[index] !== "{") return result
+    let depth = 0
+    let atProperty = true
+    for (let i = index + 1; i < tokens.length; i++) {
+      const token = tokens[i]
+      if (depth === 0 && token === "}") break
+      if (depth === 0 && atProperty) {
+        if (tokens[i + 1] === ":") result.set(propertyName(token), i + 2)
+        else if ([",", "}"].includes(tokens[i + 1])) result.set(propertyName(token), i)
+        atProperty = false
+      }
+      if (depth === 0 && token === ",") atProperty = true
+      if (["{", "(", "["].includes(token)) depth++
+      if (["}", ")", "]"].includes(token)) depth--
+    }
+    return result
+  }
+
+  function ownsWorkspace(index: number, seen = new Set<number>()): boolean {
+    index = resolveReference(index)
+    if (seen.has(index)) return false
+    seen.add(index)
+    if (tokens[index] !== "defineAgent" || tokens[index + 1] !== "(") return false
+    const options = properties(index + 2)
+    if (options.has("workspace")) return true
+    const preset = options.get("preset")
+    const registry = options.get("presets")
+    if (preset === undefined || registry === undefined) return false
+    const selection = tokens[resolveReference(preset)]
+    if (!/^["'`]/.test(selection)) return false
+    const entry = properties(registry).get(propertyName(selection))
+    return entry !== undefined && ownsWorkspace(entry, seen)
+  }
+
+  // The default export owns the folder; helper definitions and unselected presets do not.
+  if (exported !== undefined) return ownsWorkspace(exported)
+  return tokens.some((token, index) => token === "defineAgent" && ownsWorkspace(index))
 }
 function isAgentDefinitionSource(source: string): boolean {
   const stripped = stripComments(source)

--- a/packages/agent/src/discovery.ts
+++ b/packages/agent/src/discovery.ts
@@ -89,6 +89,10 @@ function isWorkspaceAgentDefinition(source: string): boolean {
         declarations.set(tokens[i + 1], i + 3)
       }
       if (tokens[i] === "export" && tokens[i + 1] === "default") exported = i + 2
+      if (tokens[i] === "export" && tokens[i + 1] === "{" ) {
+        const local = tokens[i + 2]
+        if (local && tokens[i + 3] === "as" && tokens[i + 4] === "default") exported = declarations.get(local) ?? i + 2
+      }
     }
     if (["{", "(", "["].includes(tokens[i])) depth++
     if (["}", ")", "]"].includes(tokens[i])) depth--
@@ -128,11 +132,17 @@ function isWorkspaceAgentDefinition(source: string): boolean {
 
   function ownsWorkspace(index: number, seen = new Set<number>()): boolean {
     index = resolveReference(index)
+    while (tokens[index] === "(") index++
     if (seen.has(index)) return false
     seen.add(index)
     if (tokens[index] !== "defineAgent" || tokens[index + 1] !== "(") return false
     const options = properties(index + 2)
-    if (options.has("workspace")) return true
+    const workspace = options.get("workspace")
+    if (workspace !== undefined) {
+      const value = resolveReference(workspace)
+      if (tokens[value] === "{") return true
+      if (tokens[value] === "defineWorkspace") return true
+    }
     const preset = options.get("preset")
     const registry = options.get("presets")
     if (preset === undefined || registry === undefined) return false

--- a/packages/agent/src/discovery.ts
+++ b/packages/agent/src/discovery.ts
@@ -77,6 +77,8 @@ function isWorkspaceAgentDefinition(source: string): boolean {
   const call = stripped.match(/\bdefineAgent\s*\(\s*\{/)
   if (!call || call.index === undefined) return false
   let depth = 1
+  let hasPreset = false
+  let hasPresets = false
   for (let i = call.index + call[0].length; i < stripped.length; i++) {
     const char = stripped[i]
     if (char === "{") depth++
@@ -84,9 +86,13 @@ function isWorkspaceAgentDefinition(source: string): boolean {
       depth--
       if (depth === 0) break
     }
-    if (depth === 1 && /\bworkspace\s*:/.test(stripped.slice(i))) return true
+    if (depth !== 1) continue
+    const rest = stripped.slice(i)
+    if (/^\s*workspace\s*:/.test(rest)) return true
+    if (/^\s*preset\s*:/.test(rest) || /^\s*preset\s*,/.test(rest)) hasPreset = true
+    if (/^\s*presets\s*:/.test(rest) || /^\s*presets\s*,/.test(rest)) hasPresets = true
   }
-  return false
+  return hasPreset && hasPresets
 }
 
 function isAgentDefinitionSource(source: string): boolean {

--- a/packages/agent/src/discovery.ts
+++ b/packages/agent/src/discovery.ts
@@ -76,33 +76,30 @@ function isWorkspaceAgentDefinition(source: string): boolean {
   const stripped = stripComments(source)
   const call = stripped.match(/\bdefineAgent\s*\(\s*\{/)
   if (!call || call.index === undefined) return false
-  let depth = 1
-  let hasPreset = false
-  let hasPresets = false
-  for (let i = call.index + call[0].length; i < stripped.length; i++) {
-    const char = stripped[i]
-    if (char === "{") depth++
-    else if (char === "}") {
-      depth--
-      if (depth === 0) break
-    }
+  const options = stripped.slice(call.index + call[0].length)
+  let depth = 1; let hasWorkspace = false; let presetExpr: string | undefined; let hasPresets = false
+  for (let i = 0; i < options.length; i++) {
+    const c = options[i]
+    if (c === "{") depth++
+    else if (c === "}") { depth--; if (depth === 0) break }
     if (depth !== 1) continue
-    const rest = stripped.slice(i)
-    if (/^\s*workspace\s*:/.test(rest)) return true
-    if (/^\s*preset\s*:/.test(rest) || /^\s*preset\s*,/.test(rest)) hasPreset = true
-    if (/^\s*presets\s*:/.test(rest) || /^\s*presets\s*,/.test(rest)) hasPresets = true
+    const rest = options.slice(i)
+    if (/^\s*workspace\s*:/.test(rest)) hasWorkspace = true
+    const m = rest.match(/^\s*preset\s*:\s*([^,}\n]+)/)
+    if (m) presetExpr = m[1].trim()
+    if (/^\s*preset\s*,/.test(rest)) presetExpr = "preset"
+    if (/^\s*presets\s*(?::|,)/.test(rest)) hasPresets = true
   }
-  if (!hasPreset || !hasPresets) return false
-  // Inline preset registries can own a Workspace; inspect only the selected entry.
-  const presetValue = stripped.slice(call.index + call[0].length, stripped.length).match(/(?:^|[,{}])\s*preset\s*:\s*["']([^"']+)["']/)?.[1]
-  const presetsMatch = stripped.match(/(?:^|[,{}])\s*presets\s*:\s*\{/ )
-  if (!presetValue || !presetsMatch || presetsMatch.index === undefined) return false
-  const registryStart = presetsMatch.index + presetsMatch[0].length
-  const selected = stripped.slice(registryStart).match(new RegExp(`(?:^|[,{}])\\s*${presetValue.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")}\\s*:\\s*defineAgent\\s*\\(\\s*\\{([\\s\\S]*?)\\}\\s*\\)`))
-  return !!selected && /(?:^|[,{])\s*workspace\s*:/.test(selected[1])
-  return false
+  if (hasWorkspace || !presetExpr || !hasPresets) return hasWorkspace
+  const name = presetExpr.match(/^['"]([^'"]+)['"]$/)?.[1] ?? stripped.match(new RegExp(`(?:const|let|var)\\s+${presetExpr}\\s*=\\s*['"]([^'"]+)['"]`))?.[1]
+  if (!name) return false
+  const e = name.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")
+  const entry = stripped.match(new RegExp(`${e}\\s*:\\s*(defineAgent\\s*\\(\\s*\\{[\\s\\S]*?\\}\\)|[A-Za-z_$][\\w$]*)`))?.[1]
+  if (!entry) return false
+  if (/workspace\s*:/.test(entry)) return true
+  const ref = entry.match(/^([A-Za-z_$][\w$]*)$/)?.[1]
+  return !!ref && !!stripped.match(new RegExp(`(?:const|let|var)\\s+${ref}\\s*=\\s*defineAgent\\s*\\(\\s*\\{[\\s\\S]*?workspace\\s*:`))
 }
-
 function isAgentDefinitionSource(source: string): boolean {
   const stripped = stripComments(source)
   return /\bdefineAgent\s*\(/.test(stripped)

--- a/packages/agent/src/discovery.ts
+++ b/packages/agent/src/discovery.ts
@@ -92,7 +92,26 @@ function isWorkspaceAgentDefinition(source: string): boolean {
     if (/^\s*preset\s*:/.test(rest) || /^\s*preset\s*,/.test(rest)) hasPreset = true
     if (/^\s*presets\s*:/.test(rest) || /^\s*presets\s*,/.test(rest)) hasPresets = true
   }
-  return hasPreset && hasPresets
+  if (!hasPreset || !hasPresets) return false
+  // Inline preset registries can own a Workspace even when the outer options do not.
+  // Restrict this check to the top-level `presets` property value and inspect each
+  // inline defineAgent options object for its own top-level workspace declaration.
+  const presetsMatch = stripped.match(/\bpresets\s*:\s*\{/)
+  if (!presetsMatch || presetsMatch.index === undefined) return false
+  let registryDepth = 1
+  for (let i = presetsMatch.index + presetsMatch[0].length; i < stripped.length; i++) {
+    const char = stripped[i]
+    if (char === "{") registryDepth++
+    else if (char === "}") {
+      registryDepth--
+      if (registryDepth === 0) break
+    }
+    if (registryDepth !== 1) continue
+    const rest = stripped.slice(i)
+    const inline = rest.match(/defineAgent\s*\(\s*\{([\s\S]*?)\}\s*\)/)
+    if (inline && /(?:^|[,{])\s*workspace\s*:/.test(inline[1])) return true
+  }
+  return false
 }
 
 function isAgentDefinitionSource(source: string): boolean {

--- a/packages/agent/src/discovery.ts
+++ b/packages/agent/src/discovery.ts
@@ -94,7 +94,7 @@ function isWorkspaceAgentDefinition(source: string): boolean {
   const name = presetExpr.match(/^['"]([^'"]+)['"]$/)?.[1] ?? stripped.match(new RegExp(`(?:const|let|var)\\s+${presetExpr}\\s*=\\s*['"]([^'"]+)['"]`))?.[1]
   if (!name) return false
   const e = name.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")
-  const entry = stripped.match(new RegExp(`${e}\\s*:\\s*(defineAgent\\s*\\(\\s*\\{[\\s\\S]*?\\}\\)|[A-Za-z_$][\\w$]*)`))?.[1]
+  const entry = stripped.match(new RegExp(`${e}\\s*:\\s*(defineAgent\\s*\\(\\s*\\{[\\s\\S]*?\\}\\)|[A-Za-z_$][\\w$]*)`))?.[1] ?? (stripped.match(new RegExp(`(?:[,{]\\s*)${e}\\s*(?=[,}])`)) ? name : undefined)
   if (!entry) return false
   if (/workspace\s*:/.test(entry)) return true
   const ref = entry.match(/^([A-Za-z_$][\w$]*)$/)?.[1]

--- a/packages/agent/src/discovery.ts
+++ b/packages/agent/src/discovery.ts
@@ -75,8 +75,10 @@ function stripComments(source: string) {
 function isWorkspaceAgentDefinition(source: string): boolean {
   const stripped = stripComments(source)
   // Named presets may contribute an inline workspace only after runtime resolution.
-  // Treat preset based definitions as workspace candidates so hosted setup inspects them.
-  return /\bdefineAgent\s*\(\s*\{[\s\S]*?(?:\bworkspace\s*:|\bpreset\s*:)/.test(stripped)
+  // Treat definitions that select a preset as workspace candidates so hosted setup
+  // inspects the resolved definition. Support both object properties and shorthand
+  // variables (`const preset = "name"; defineAgent({ preset, ... })`).
+  return /\bdefineAgent\s*\(\s*\{[\s\S]*?(?:\bworkspace\s*:|\bpreset\s*(?::|[,}]))/.test(stripped)
 }
 
 function isAgentDefinitionSource(source: string): boolean {

--- a/packages/agent/src/discovery.ts
+++ b/packages/agent/src/discovery.ts
@@ -177,8 +177,12 @@ function isWorkspaceAgentDefinition(source: string): boolean {
             const literalParts: string[] = []
             for (let p = 0; p < expression.length; p += 2) {
               const part = expression[p]
-              if (!part || !/^["'`]/.test(part)) { key = undefined; break }
-              literalParts.push(propertyName(part))
+              if (!part) { key = undefined; break }
+              const partIndex = tokens.indexOf(part, i + 1)
+              const resolved = partIndex >= 0 ? resolveReference(partIndex) : partIndex
+              const value = resolved >= 0 ? tokens[resolved] : part
+              if (!value || !/^["'`]/.test(value)) { key = undefined; break }
+              literalParts.push(propertyName(value))
               if (p + 1 < expression.length && expression[p + 1] !== "+") { key = undefined; break }
             }
             if (literalParts.length) key = literalParts.join("")

--- a/packages/agent/src/discovery.ts
+++ b/packages/agent/src/discovery.ts
@@ -74,11 +74,10 @@ function stripComments(source: string) {
 
 function isWorkspaceAgentDefinition(source: string): boolean {
   const stripped = stripComments(source)
-  // Named presets may contribute an inline workspace only after runtime resolution.
-  // Treat definitions that select a preset as workspace candidates so hosted setup
-  // inspects the resolved definition. Support both object properties and shorthand
-  // variables (`const preset = "name"; defineAgent({ preset, ... })`).
-  return /\bdefineAgent\s*\(\s*\{[\s\S]*?(?:\bworkspace\s*:|\bpreset\s*(?::|[,}]))/.test(stripped)
+  // A preset selection alone does not imply Workspace ownership. Classify inline
+  // preset definitions only when the source also contains a workspace property;
+  // this avoids registering ordinary presets as hosted Workspaces.
+  return /\bdefineAgent\s*\(\s*\{[\s\S]*\bworkspace\s*:/.test(stripped)
 }
 
 function isAgentDefinitionSource(source: string): boolean {

--- a/packages/agent/src/discovery.ts
+++ b/packages/agent/src/discovery.ts
@@ -73,7 +73,10 @@ function stripComments(source: string) {
 }
 
 function isWorkspaceAgentDefinition(source: string): boolean {
-  return /\bdefineAgent\s*\(\s*\{[\s\S]*?\bworkspace\s*:/.test(stripComments(source))
+  const stripped = stripComments(source)
+  // Named presets may contribute an inline workspace only after runtime resolution.
+  // Treat preset based definitions as workspace candidates so hosted setup inspects them.
+  return /\bdefineAgent\s*\(\s*\{[\s\S]*?(?:\bworkspace\s*:|\bpreset\s*:)/.test(stripped)
 }
 
 function isAgentDefinitionSource(source: string): boolean {

--- a/packages/agent/src/discovery.ts
+++ b/packages/agent/src/discovery.ts
@@ -90,7 +90,19 @@ function isWorkspaceAgentDefinition(source: string): boolean {
         // Dynamic imports are expressions, not static declarations. Ignore
         // them entirely so identifiers in the surrounding module cannot be
         // mistaken for imported Workspace bindings.
-        if (tokens[i + 1] === "(") continue
+        if (tokens[i + 1] === "(") {
+          // Skip the complete dynamic import expression; its argument may
+          // contain identifiers that must not be treated as static imports.
+          let dynamicDepth = 0
+          for (let j = i + 1; j < tokens.length; j++) {
+            if (tokens[j] === "(") dynamicDepth++
+            else if (tokens[j] === ")" && --dynamicDepth === 0) {
+              i = j
+              break
+            }
+          }
+          continue
+        }
         // Imports are often semicolonless; stop at the module specifier rather
         // than consuming identifiers from following declarations.
         let sawFrom = false

--- a/packages/agent/src/discovery.ts
+++ b/packages/agent/src/discovery.ts
@@ -175,17 +175,18 @@ function isWorkspaceAgentDefinition(source: string): boolean {
             const expression = tokens.slice(i + 1, close - 1).filter(token => token !== "(" && token !== ")")
             let key: string | undefined
             const literalParts: string[] = []
+            let valid = true
             for (let p = 0; p < expression.length; p += 2) {
               const part = expression[p]
-              if (!part) { key = undefined; break }
+              if (!part) { valid = false; break }
               const partIndex = tokens.indexOf(part, i + 1)
               const resolved = partIndex >= 0 ? resolveReference(partIndex) : partIndex
               const value = resolved >= 0 ? tokens[resolved] : part
-              if (!value || !/^["'`]/.test(value)) { key = undefined; break }
+              if (!value || !/^["'`]/.test(value)) { valid = false; break }
               literalParts.push(propertyName(value))
-              if (p + 1 < expression.length && expression[p + 1] !== "+") { key = undefined; break }
+              if (p + 1 < expression.length && expression[p + 1] !== "+") { valid = false; break }
             }
-            if (literalParts.length) key = literalParts.join("")
+            if (valid && literalParts.length) key = literalParts.join("")
             if (key !== undefined) result.set(key, close + 1)
             i = close
             atProperty = false

--- a/packages/agent/src/index.ts
+++ b/packages/agent/src/index.ts
@@ -2122,55 +2122,58 @@ export interface DefineAgent {
     TRuntimeConfig extends AgentRuntimeConfig = AgentRuntimeConfig,
     CALL_OPTIONS = unknown,
     const TInvokerProfile extends AgentInvokerProfile = AgentInvokerProfile,
-    TContextValues extends object = AgentInvocationContextValues,
+    const TCapabilities extends AgentStaticCapabilitiesList<TRuntimeConfig> | undefined = undefined,
+    TContextValues extends object = AgentCapabilitiesInvocationContextValues<TCapabilities>,
     const TWorkspace extends WorkspaceAgentWorkspaceConfig | undefined = undefined,
     TOutput = unknown,
   >(
-    options: Omit<Partial<AgentSettings<TRuntimeConfig, CALL_OPTIONS, TInvokerProfile, TContextValues, AgentCapabilitiesInput<TRuntimeConfig>, TOutput>>, "driver" | "workspace"> & {
+    options: Omit<Partial<AgentSettings<TRuntimeConfig, CALL_OPTIONS, TInvokerProfile, TContextValues, AgentCapabilitiesOption<TRuntimeConfig, WorkspaceName, CALL_OPTIONS, TCapabilities>, TOutput>>, "driver" | "workspace"> & {
       preset: TPreset
       presets: Record<NoInfer<TPreset>, AgentDefinition<TRuntimeConfig, CALL_OPTIONS, TInvokerProfile, TContextValues, TOutput> & { __vitehubWorkspaceAgent: true }> & Record<string, unknown>
       extends?: never
-      driver?: Partial<AgentSettings<TRuntimeConfig, CALL_OPTIONS, TInvokerProfile, TContextValues, AgentCapabilitiesInput<TRuntimeConfig>, TOutput>["driver"]>
+      driver?: Partial<AgentSettings<TRuntimeConfig, CALL_OPTIONS, TInvokerProfile, TContextValues, AgentCapabilitiesOption<TRuntimeConfig, WorkspaceName, CALL_OPTIONS, TCapabilities>, TOutput>["driver"]>
       workspace?: WorkspaceAgentWorkspaceConfig
     },
-  ): WorkspaceAgentDefinition<TRuntimeConfig, WorkspaceName, CALL_OPTIONS, TInvokerProfile, TContextValues, AgentCapabilitiesInput<TRuntimeConfig>, TOutput>
+  ): WorkspaceAgentDefinition<TRuntimeConfig, WorkspaceName, CALL_OPTIONS, TInvokerProfile, TContextValues, AgentCapabilitiesOption<TRuntimeConfig, WorkspaceName, CALL_OPTIONS, TCapabilities>, TOutput>
 
   <
     const TPreset extends string,
     TRuntimeConfig extends AgentRuntimeConfig = AgentRuntimeConfig,
     CALL_OPTIONS = unknown,
     const TInvokerProfile extends AgentInvokerProfile = AgentInvokerProfile,
-    TContextValues extends object = AgentInvocationContextValues,
+    const TCapabilities extends AgentStaticCapabilitiesList<TRuntimeConfig> | undefined = undefined,
+    TContextValues extends object = AgentCapabilitiesInvocationContextValues<TCapabilities>,
     const TWorkspace extends WorkspaceAgentWorkspaceConfig | undefined = undefined,
     TOutput = unknown,
   >(
-    options: Omit<Partial<AgentSettings<TRuntimeConfig, CALL_OPTIONS, TInvokerProfile, TContextValues, AgentCapabilitiesInput<TRuntimeConfig>, TOutput>>, "driver" | "workspace"> & {
+    options: Omit<Partial<AgentSettings<TRuntimeConfig, CALL_OPTIONS, TInvokerProfile, TContextValues, AgentCapabilitiesOption<TRuntimeConfig, WorkspaceName, CALL_OPTIONS, TCapabilities>, TOutput>>, "driver" | "workspace"> & {
       preset: TPreset
       presets: Record<NoInfer<TPreset>, AgentDefinition<TRuntimeConfig, CALL_OPTIONS, TInvokerProfile, TContextValues, TOutput>> & Record<string, unknown>
       extends?: never
-      driver?: Partial<AgentSettings<TRuntimeConfig, CALL_OPTIONS, TInvokerProfile, TContextValues, AgentCapabilitiesInput<TRuntimeConfig>, TOutput>["driver"]>
+      driver?: Partial<AgentSettings<TRuntimeConfig, CALL_OPTIONS, TInvokerProfile, TContextValues, AgentCapabilitiesOption<TRuntimeConfig, WorkspaceName, CALL_OPTIONS, TCapabilities>, TOutput>["driver"]>
       workspace: WorkspaceAgentWorkspaceConfig
     },
-  ): WorkspaceAgentDefinition<TRuntimeConfig, WorkspaceName, CALL_OPTIONS, TInvokerProfile, TContextValues, AgentCapabilitiesInput<TRuntimeConfig>, TOutput>
+  ): WorkspaceAgentDefinition<TRuntimeConfig, WorkspaceName, CALL_OPTIONS, TInvokerProfile, TContextValues, AgentCapabilitiesOption<TRuntimeConfig, WorkspaceName, CALL_OPTIONS, TCapabilities>, TOutput>
 
   <
     const TPreset extends string,
     TRuntimeConfig extends AgentRuntimeConfig = AgentRuntimeConfig,
     CALL_OPTIONS = unknown,
     const TInvokerProfile extends AgentInvokerProfile = AgentInvokerProfile,
-    TContextValues extends object = AgentInvocationContextValues,
+    const TCapabilities extends AgentStaticCapabilitiesList<TRuntimeConfig> | undefined = undefined,
+    TContextValues extends object = AgentCapabilitiesInvocationContextValues<TCapabilities>,
     const TWorkspace extends WorkspaceAgentWorkspaceConfig | undefined = undefined,
     TOutput = unknown,
   >(
-    options: Omit<Partial<AgentSettings<TRuntimeConfig, CALL_OPTIONS, TInvokerProfile, TContextValues, AgentCapabilitiesInput<TRuntimeConfig>, TOutput>>, "driver" | "workspace"> & {
+    options: Omit<Partial<AgentSettings<TRuntimeConfig, CALL_OPTIONS, TInvokerProfile, TContextValues, AgentCapabilitiesOption<TRuntimeConfig, WorkspaceName, CALL_OPTIONS, TCapabilities>, TOutput>>, "driver" | "workspace"> & {
       preset: TPreset
       presets: Record<NoInfer<TPreset>, AgentDefinition<TRuntimeConfig, CALL_OPTIONS, TInvokerProfile, TContextValues, TOutput>> & Record<string, unknown>
       extends?: never
-      driver?: Partial<AgentSettings<TRuntimeConfig, CALL_OPTIONS, TInvokerProfile, TContextValues, AgentCapabilitiesInput<TRuntimeConfig>, TOutput>["driver"]>
+      driver?: Partial<AgentSettings<TRuntimeConfig, CALL_OPTIONS, TInvokerProfile, TContextValues, AgentCapabilitiesOption<TRuntimeConfig, WorkspaceName, CALL_OPTIONS, TCapabilities>, TOutput>["driver"]>
       workspace?: TWorkspace
     },
   ): TWorkspace extends WorkspaceAgentWorkspaceConfig
-    ? WorkspaceAgentDefinition<TRuntimeConfig, WorkspaceName, CALL_OPTIONS, TInvokerProfile, TContextValues, AgentCapabilitiesInput<TRuntimeConfig>, TOutput>
+    ? WorkspaceAgentDefinition<TRuntimeConfig, WorkspaceName, CALL_OPTIONS, TInvokerProfile, TContextValues, AgentCapabilitiesOption<TRuntimeConfig, WorkspaceName, CALL_OPTIONS, TCapabilities>, TOutput>
     : AgentDefinition<TRuntimeConfig, CALL_OPTIONS, TInvokerProfile, TContextValues, TOutput>
 
   <

--- a/packages/agent/src/index.ts
+++ b/packages/agent/src/index.ts
@@ -2123,6 +2123,7 @@ export interface DefineAgent {
     CALL_OPTIONS = unknown,
     const TInvokerProfile extends AgentInvokerProfile = AgentInvokerProfile,
     TContextValues extends object = AgentInvocationContextValues,
+    const TWorkspace extends WorkspaceAgentWorkspaceConfig | undefined = undefined,
     TOutput = unknown,
   >(
     options: Omit<Partial<AgentSettings<TRuntimeConfig, CALL_OPTIONS, TInvokerProfile, TContextValues, AgentCapabilitiesInput<TRuntimeConfig>, TOutput>>, "driver" | "workspace"> & {
@@ -2164,9 +2165,11 @@ export interface DefineAgent {
       presets: Record<NoInfer<TPreset>, AgentDefinition<TRuntimeConfig, CALL_OPTIONS, TInvokerProfile, TContextValues, TOutput>> & Record<string, unknown>
       extends?: never
       driver?: Partial<AgentSettings<TRuntimeConfig, CALL_OPTIONS, TInvokerProfile, TContextValues, AgentCapabilitiesInput<TRuntimeConfig>, TOutput>["driver"]>
-      workspace?: WorkspaceAgentWorkspaceConfig
+      workspace?: TWorkspace
     },
-  ): AgentDefinition<TRuntimeConfig, CALL_OPTIONS, TInvokerProfile, TContextValues, TOutput>
+  ): TWorkspace extends WorkspaceAgentWorkspaceConfig
+    ? WorkspaceAgentDefinition<TRuntimeConfig, WorkspaceName, CALL_OPTIONS, TInvokerProfile, TContextValues, AgentCapabilitiesInput<TRuntimeConfig>, TOutput>
+    : AgentDefinition<TRuntimeConfig, CALL_OPTIONS, TInvokerProfile, TContextValues, TOutput>
 
   <
     TRuntimeConfig extends AgentRuntimeConfig = AgentRuntimeConfig,

--- a/packages/agent/src/index.ts
+++ b/packages/agent/src/index.ts
@@ -2118,8 +2118,8 @@ type AgentInvokerProfileOf<TOptions> = "invoker" extends keyof TOptions
 
 export interface DefineAgent {
   <
-    const TPreset extends string,
     TRuntimeConfig extends AgentRuntimeConfig = AgentRuntimeConfig,
+    const TPreset extends string = string,
     CALL_OPTIONS = unknown,
     const TInvokerProfile extends AgentInvokerProfile = AgentInvokerProfile,
     const TCapabilities extends AgentStaticCapabilitiesList<TRuntimeConfig> | undefined = undefined,
@@ -2137,8 +2137,8 @@ export interface DefineAgent {
   ): WorkspaceAgentDefinition<TRuntimeConfig, WorkspaceName, CALL_OPTIONS, TInvokerProfile, TContextValues, AgentCapabilitiesOption<TRuntimeConfig, WorkspaceName, CALL_OPTIONS, TCapabilities>, TOutput>
 
   <
-    const TPreset extends string,
     TRuntimeConfig extends AgentRuntimeConfig = AgentRuntimeConfig,
+    const TPreset extends string = string,
     CALL_OPTIONS = unknown,
     const TInvokerProfile extends AgentInvokerProfile = AgentInvokerProfile,
     const TCapabilities extends AgentStaticCapabilitiesList<TRuntimeConfig> | undefined = undefined,
@@ -2156,8 +2156,8 @@ export interface DefineAgent {
   ): WorkspaceAgentDefinition<TRuntimeConfig, WorkspaceName, CALL_OPTIONS, TInvokerProfile, TContextValues, AgentCapabilitiesOption<TRuntimeConfig, WorkspaceName, CALL_OPTIONS, TCapabilities>, TOutput>
 
   <
-    const TPreset extends string,
     TRuntimeConfig extends AgentRuntimeConfig = AgentRuntimeConfig,
+    const TPreset extends string = string,
     CALL_OPTIONS = unknown,
     const TInvokerProfile extends AgentInvokerProfile = AgentInvokerProfile,
     const TCapabilities extends AgentStaticCapabilitiesList<TRuntimeConfig> | undefined = undefined,

--- a/packages/agent/src/index.ts
+++ b/packages/agent/src/index.ts
@@ -2118,6 +2118,40 @@ type AgentInvokerProfileOf<TOptions> = "invoker" extends keyof TOptions
 
 export interface DefineAgent {
   <
+    const TPreset extends string,
+    TRuntimeConfig extends AgentRuntimeConfig = AgentRuntimeConfig,
+    CALL_OPTIONS = unknown,
+    const TInvokerProfile extends AgentInvokerProfile = AgentInvokerProfile,
+    TContextValues extends object = AgentInvocationContextValues,
+    TOutput = unknown,
+  >(
+    options: Omit<Partial<AgentSettings<TRuntimeConfig, CALL_OPTIONS, TInvokerProfile, TContextValues, AgentCapabilitiesInput<TRuntimeConfig>, TOutput>>, "driver" | "workspace"> & {
+      preset: TPreset
+      presets: Record<NoInfer<TPreset>, AgentDefinition<TRuntimeConfig, CALL_OPTIONS, TInvokerProfile, TContextValues, TOutput> & { __vitehubWorkspaceAgent: true }> & Record<string, unknown>
+      extends?: never
+      driver?: Partial<AgentSettings<TRuntimeConfig, CALL_OPTIONS, TInvokerProfile, TContextValues, AgentCapabilitiesInput<TRuntimeConfig>, TOutput>["driver"]>
+      workspace?: WorkspaceAgentWorkspaceConfig
+    },
+  ): WorkspaceAgentDefinition<TRuntimeConfig, WorkspaceName, CALL_OPTIONS, TInvokerProfile, TContextValues, AgentCapabilitiesInput<TRuntimeConfig>, TOutput>
+
+  <
+    const TPreset extends string,
+    TRuntimeConfig extends AgentRuntimeConfig = AgentRuntimeConfig,
+    CALL_OPTIONS = unknown,
+    const TInvokerProfile extends AgentInvokerProfile = AgentInvokerProfile,
+    TContextValues extends object = AgentInvocationContextValues,
+    TOutput = unknown,
+  >(
+    options: Omit<Partial<AgentSettings<TRuntimeConfig, CALL_OPTIONS, TInvokerProfile, TContextValues, AgentCapabilitiesInput<TRuntimeConfig>, TOutput>>, "driver" | "workspace"> & {
+      preset: TPreset
+      presets: Record<NoInfer<TPreset>, AgentDefinition<TRuntimeConfig, CALL_OPTIONS, TInvokerProfile, TContextValues, TOutput>> & Record<string, unknown>
+      extends?: never
+      driver?: Partial<AgentSettings<TRuntimeConfig, CALL_OPTIONS, TInvokerProfile, TContextValues, AgentCapabilitiesInput<TRuntimeConfig>, TOutput>["driver"]>
+      workspace?: WorkspaceAgentWorkspaceConfig
+    },
+  ): AgentDefinition<TRuntimeConfig, CALL_OPTIONS, TInvokerProfile, TContextValues, TOutput>
+
+  <
     TRuntimeConfig extends AgentRuntimeConfig = AgentRuntimeConfig,
     CALL_OPTIONS = unknown,
     const TInvokerProfile extends AgentInvokerProfile = AgentInvokerProfile,

--- a/packages/agent/src/index.ts
+++ b/packages/agent/src/index.ts
@@ -2141,6 +2141,7 @@ export interface DefineAgent {
     CALL_OPTIONS = unknown,
     const TInvokerProfile extends AgentInvokerProfile = AgentInvokerProfile,
     TContextValues extends object = AgentInvocationContextValues,
+    const TWorkspace extends WorkspaceAgentWorkspaceConfig | undefined = undefined,
     TOutput = unknown,
   >(
     options: Omit<Partial<AgentSettings<TRuntimeConfig, CALL_OPTIONS, TInvokerProfile, TContextValues, AgentCapabilitiesInput<TRuntimeConfig>, TOutput>>, "driver" | "workspace"> & {

--- a/packages/agent/src/index.ts
+++ b/packages/agent/src/index.ts
@@ -2147,6 +2147,23 @@ export interface DefineAgent {
       presets: Record<NoInfer<TPreset>, AgentDefinition<TRuntimeConfig, CALL_OPTIONS, TInvokerProfile, TContextValues, TOutput>> & Record<string, unknown>
       extends?: never
       driver?: Partial<AgentSettings<TRuntimeConfig, CALL_OPTIONS, TInvokerProfile, TContextValues, AgentCapabilitiesInput<TRuntimeConfig>, TOutput>["driver"]>
+      workspace: WorkspaceAgentWorkspaceConfig
+    },
+  ): WorkspaceAgentDefinition<TRuntimeConfig, WorkspaceName, CALL_OPTIONS, TInvokerProfile, TContextValues, AgentCapabilitiesInput<TRuntimeConfig>, TOutput>
+
+  <
+    const TPreset extends string,
+    TRuntimeConfig extends AgentRuntimeConfig = AgentRuntimeConfig,
+    CALL_OPTIONS = unknown,
+    const TInvokerProfile extends AgentInvokerProfile = AgentInvokerProfile,
+    TContextValues extends object = AgentInvocationContextValues,
+    TOutput = unknown,
+  >(
+    options: Omit<Partial<AgentSettings<TRuntimeConfig, CALL_OPTIONS, TInvokerProfile, TContextValues, AgentCapabilitiesInput<TRuntimeConfig>, TOutput>>, "driver" | "workspace"> & {
+      preset: TPreset
+      presets: Record<NoInfer<TPreset>, AgentDefinition<TRuntimeConfig, CALL_OPTIONS, TInvokerProfile, TContextValues, TOutput>> & Record<string, unknown>
+      extends?: never
+      driver?: Partial<AgentSettings<TRuntimeConfig, CALL_OPTIONS, TInvokerProfile, TContextValues, AgentCapabilitiesInput<TRuntimeConfig>, TOutput>["driver"]>
       workspace?: WorkspaceAgentWorkspaceConfig
     },
   ): AgentDefinition<TRuntimeConfig, CALL_OPTIONS, TInvokerProfile, TContextValues, TOutput>

--- a/packages/agent/src/index.ts
+++ b/packages/agent/src/index.ts
@@ -2159,6 +2159,7 @@ export interface DefineAgent {
     CALL_OPTIONS = unknown,
     const TInvokerProfile extends AgentInvokerProfile = AgentInvokerProfile,
     TContextValues extends object = AgentInvocationContextValues,
+    const TWorkspace extends WorkspaceAgentWorkspaceConfig | undefined = undefined,
     TOutput = unknown,
   >(
     options: Omit<Partial<AgentSettings<TRuntimeConfig, CALL_OPTIONS, TInvokerProfile, TContextValues, AgentCapabilitiesInput<TRuntimeConfig>, TOutput>>, "driver" | "workspace"> & {

--- a/packages/agent/test/agent-presets.test-d.ts
+++ b/packages/agent/test/agent-presets.test-d.ts
@@ -1,0 +1,16 @@
+import { expectTypeOf, it } from "vitest"
+import { defineAgent } from "../src/index.ts"
+
+it("infers the selected preset and rejects unknown names", () => {
+  const notes = defineAgent({ driver: "codex", workspace: {} })
+  const other = defineAgent({ driver: { run: () => ({ text: "other" }) } })
+  const agent = defineAgent({ preset: "notes", presets: { notes, other }, driver: { model: "custom" } })
+  expectTypeOf(agent.__vitehubWorkspaceAgent).toEqualTypeOf<true>()
+
+  // @ts-expect-error The selected name must exist in the local registry.
+  defineAgent({ preset: "missing", presets: { notes } })
+  // @ts-expect-error Presets must be Agent Definitions.
+  defineAgent({ preset: "notes", presets: { notes: { driver: "codex" } } })
+  // @ts-expect-error The composition has exactly one parent.
+  defineAgent({ preset: "notes", presets: { notes }, extends: notes })
+})

--- a/packages/agent/test/agent-presets.test.ts
+++ b/packages/agent/test/agent-presets.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it, vi } from "vitest"
+import { defineAgent, runAgent } from "../src/index.ts"
+
+describe("named Agent presets", () => {
+  it("runs a selected published definition with local overrides", async () => {
+    const run = vi.fn(() => ({ text: "notes" }))
+    const unused = vi.fn(() => ({ text: "unused" }))
+    const notetaker = defineAgent({ name: "published-notetaker", driver: { run } })
+    const agent = defineAgent({
+      preset: "notetaker",
+      presets: { notetaker, other: defineAgent({ driver: { run: unused } }) },
+      description: "Local notes",
+    })
+    await runAgent(agent, { runtime: "unknown", memo: vi.fn(), waitUntil: vi.fn() }, { prompt: "Summarize this" })
+    expect(run).toHaveBeenCalledTimes(1)
+    expect(unused).not.toHaveBeenCalled()
+    expect(agent.name).toBeUndefined()
+    expect(agent.description).toBe("Local notes")
+    expect(notetaker.name).toBe("published-notetaker")
+    expect(agent.resolve).not.toBe(notetaker.resolve)
+  })
+
+  it("keeps registries local and composes named presets through multiple generations", () => {
+    const first = defineAgent({ driver: { kind: "codex", model: "first" }, workspace: {} })
+    const second = defineAgent({ preset: "notes", presets: { notes: first }, driver: { model: "second" } })
+    const third = defineAgent({ preset: "notes", presets: { notes: second }, description: "third" })
+    expect(second.__vitehubWorkspaceAgentOptions.driver).toMatchObject({ model: "second" })
+    expect(third.__vitehubWorkspaceAgentOptions.driver).toMatchObject({ model: "second" })
+    expect(third.__vitehubWorkspaceAgentOptions).not.toHaveProperty("presets")
+    expect(third.__vitehubWorkspaceAgentOptions).not.toHaveProperty("preset")
+    expect(first.__vitehubWorkspaceAgentOptions.driver).toMatchObject({ model: "first" })
+  })
+
+  it("rejects missing, inherited, invalid and ambiguous selections", () => {
+    const base = defineAgent({ driver: "codex" })
+    expect(() => defineAgent({ preset: "missing", presets: { notes: base } } as never)).toThrow('preset "missing" is not defined')
+    expect(() => defineAgent({ preset: "toString", presets: {} } as never)).toThrow('preset "toString" is not defined')
+    expect(() => defineAgent({ presets: { notes: base } } as never)).toThrow("requires a non-empty preset name")
+    expect(() => defineAgent({ preset: "notes", presets: { notes: {} } } as never)).toThrow("requires an Agent Definition")
+    expect(() => defineAgent({ preset: "notes", presets: { notes: base }, extends: base } as never)).toThrow("Select one Agent parent")
+  })
+})

--- a/packages/agent/test/agent-presets.test.ts
+++ b/packages/agent/test/agent-presets.test.ts
@@ -31,6 +31,10 @@ describe("named Agent presets", () => {
     expect(first.__vitehubWorkspaceAgentOptions.driver).toMatchObject({ model: "first" })
   })
 
+  it.each([undefined, null, false, 42, {}, [], "", " "])("rejects malformed preset %j without a registry", (preset) => {
+    expect(() => defineAgent({ preset } as never)).toThrow("requires a non-empty preset name")
+  })
+
   it("rejects missing, inherited, invalid and ambiguous selections", () => {
     const base = defineAgent({ driver: "codex" })
     expect(() => defineAgent({ preset: "missing", presets: { notes: base } } as never)).toThrow('preset "missing" is not defined')

--- a/packages/agent/test/discovery.test.ts
+++ b/packages/agent/test/discovery.test.ts
@@ -1899,3 +1899,33 @@ describe("agent chat capability discovery", () => {
 
 
 })
+
+
+it.each([
+  ['export default defineAgent({ description: "}", workspace: {} })', true],
+  ["export default defineAgent({ description: `}`, workspace: {} })", true],
+  ['export default defineAgent({ pattern: /[}]/, workspace: {} })', true],
+  ['const helper = defineAgent({}); export default defineAgent({ workspace: {} })', true],
+  ['const helper = defineAgent({ workspace: {} }); export default defineAgent({})', false],
+  ['const unrelated = { notes: defineAgent({ workspace: {} }) }; export default defineAgent({ preset: "notes", presets: { notes: defineAgent({}) } })', false],
+  ['export default defineAgent({ preset: "notes", presets: { notes: defineAgent({}) } }); const unrelated = { notes: defineAgent({ workspace: {} }) }', false],
+  ['export default defineAgent({ preset: "notes", presets: { other: defineAgent({ workspace: {} }), notes: defineAgent({}) } })', false],
+  ['export default defineAgent({ preset: "notes", presets: { notes: defineAgent({ workspace: {} }) } })', true],
+  ['const notes = defineAgent({ workspace: {} }); export default defineAgent({ preset: "notes", presets: { notes } })', true],
+  ['const notes = defineAgent({}); const unrelated = { notes: defineAgent({ workspace: {} }) }; export default defineAgent({ preset: "notes", presets: { notes } })', false],
+  ['const notes = defineAgent({ workspace: {} }); const preset = "notes"; const presets = { notes }; const agent = defineAgent({ preset, presets }); export default agent', true],
+  ['export default defineAgent({ driver: { providerSettings: { workspace: {} } } })', false],
+])("discovers Workspace ownership from the selected exported Agent: %s", async (source, workspace) => {
+  const root = await createTempRoot("vitehub-agent-preset-discovery-")
+  try {
+    const folder = join(root, "server", "agents", "notes")
+    await mkdir(folder, { recursive: true })
+    await writeFile(join(folder, "agent.ts"), source)
+    const definitions = discoverAgentDefinitions({ mode: "server-agents", scanDirs: [join(root, "server")] })
+    expect(definitions).toHaveLength(1)
+    expect(definitions[0].workspace).toBe(workspace ? "notes" : undefined)
+  }
+  finally {
+    await rm(root, { force: true, recursive: true })
+  }
+})


### PR DESCRIPTION
## What changed

Add a named preset registry to the agent definition API. Applications can pass an imported preset definition through `presets` and select it with `preset: "name"`; the selected definition is resolved into the existing layer merge path.

This keeps third-party presets as ordinary `defineAgent` exports and avoids dynamic package loading in the core runtime.

## Validation

- Agent dependency build and publint
- Runtime and type tests on the preset registry branch