### PR TITLE
feat(agent): compose instruction templates through presets

### DIFF
--- a/packages/agent/README.md
+++ b/packages/agent/README.md
@@ -494,3 +494,36 @@ Capability definitions can declare `inspection: { label, view? }`. Lifecycle hoo
 MCP records server discovery and tool provenance. Title records generation settings, progress, and its result. The Console's Capabilities tab reads these snapshots without invoking either capability. Other capabilities use the default tools/configuration view. Set the Invocation journal's `configuration` to `"content"` to retain inspection state and views independently of other trace content. Metadata-only capture keeps labels. Existing redaction and observation bounds apply.
 
 See [custom capability inspection](https://vitehub.dev/docs/capabilities/custom-capabilities#contribute-an-inspection-view) for the catalog and a complete example.
+
+
+### Instruction templates
+
+An Agent can reserve one place for extending instructions. Define a template in
+`driver.instructions` with exactly one `{{{ instructions }}}` marker outside code:
+
+```ts
+const base = defineAgent({
+  driver: {
+    kind: "codex",
+    instructions: {
+      template: "Inspect the request.\n\n{{{ instructions }}}\n\nExplain the result.",
+      content: "Use concise language.",
+    },
+  },
+})
+
+const agent = defineAgent({
+  extends: base,
+  driver: { instructions: "Check migration safety." },
+})
+```
+
+The extension replaces the slot content. It does not append instructions or add
+headings. Omitted content uses the inherited default. Strings, arrays, and async
+instruction resolvers work in both `template` and `content`. Markdown files can
+be loaded through the existing instruction resolver or Markdown import path.
+
+To discard the inherited template, use
+`instructions: { mode: "replace", value: "A complete instruction document." }`.
+A new `{ template, content }` object also replaces the inherited template.
+Without a template, extending instructions replaces the inherited document.

--- a/packages/agent/src/agent-instructions.ts
+++ b/packages/agent/src/agent-instructions.ts
@@ -8,8 +8,8 @@ async function resolveContent<TRuntimeConfig extends AgentRuntimeConfig, Name ex
   context: AgentAdapterMetadataContext<TRuntimeConfig, Name>,
   preserveWhitespace = false,
 ): Promise<string> {
-  const parts = Array.isArray(input) ? input : [input]
-  const resolved = await Promise.all(parts.map(part => hasRuntimeType(part, "function") ? part(context) : part))
+  const inputParts = Array.isArray(input) ? input : [input]
+  const resolved = await Promise.all(inputParts.map(part => hasRuntimeType(part, "function") ? part(context) : part))
   const parts = resolved.flatMap(part => Array.isArray(part) ? part : [part]).filter((part): part is string => hasRuntimeType(part, "string"))
   return preserveWhitespace ? parts.join("\n\n") : parts.map(part => part.trim()).filter(Boolean).join("\n\n")
 }

--- a/packages/agent/src/agent-instructions.ts
+++ b/packages/agent/src/agent-instructions.ts
@@ -19,9 +19,11 @@ export async function resolveAgentInstructions<TRuntimeConfig extends AgentRunti
 ): Promise<string> {
   if (input && hasRuntimeType(input, "object") && !Array.isArray(input) && ("mode" in input || "template" in input)) {
     if ("mode" in input) {
+      // SAFETY: mode discriminant identifies replacement instructions.
       const replacement = input as Extract<AgentAdapterInstructions<TRuntimeConfig, Name>, { mode: "replace" }>
       return await resolveContent(replacement.value, context)
     }
+    // SAFETY: template discriminant identifies composed instructions.
     const composed = input as Extract<AgentAdapterInstructions<TRuntimeConfig, Name>, { template: unknown }>
     const template = await resolveContent(composed.template, context)
     const content = await resolveContent(composed.content, context)

--- a/packages/agent/src/agent-instructions.ts
+++ b/packages/agent/src/agent-instructions.ts
@@ -6,10 +6,12 @@ import type { AgentAdapterInstructions, AgentAdapterMetadataContext, AgentInstru
 async function resolveContent<TRuntimeConfig extends AgentRuntimeConfig, Name extends WorkspaceName>(
   input: AgentInstructionsContent<TRuntimeConfig, Name> | undefined,
   context: AgentAdapterMetadataContext<TRuntimeConfig, Name>,
+  preserveWhitespace = false,
 ): Promise<string> {
   const parts = Array.isArray(input) ? input : [input]
   const resolved = await Promise.all(parts.map(part => hasRuntimeType(part, "function") ? part(context) : part))
-  return resolved.flatMap(part => Array.isArray(part) ? part : [part]).map(part => part?.trim()).filter(Boolean).join("\n\n")
+  const parts = resolved.flatMap(part => Array.isArray(part) ? part : [part]).filter((part): part is string => hasRuntimeType(part, "string"))
+  return preserveWhitespace ? parts.join("\n\n") : parts.map(part => part.trim()).filter(Boolean).join("\n\n")
 }
 
 /** Resolve one document before provider-specific instruction composition. */
@@ -25,7 +27,7 @@ export async function resolveAgentInstructions<TRuntimeConfig extends AgentRunti
     }
     // SAFETY: template discriminant identifies composed instructions.
     const composed = input as Extract<AgentAdapterInstructions<TRuntimeConfig, Name>, { template: unknown }>
-    const template = await resolveContent(composed.template, context)
+    const template = await resolveContent(composed.template, context, true)
     const content = await resolveContent(composed.content, context)
     return await fillInstructionSlot(template, content)
   }

--- a/packages/agent/src/agent-instructions.ts
+++ b/packages/agent/src/agent-instructions.ts
@@ -40,9 +40,11 @@ export function agentInstructionSources<TRuntimeConfig extends AgentRuntimeConfi
 ) {
   if (input && hasRuntimeType(input, "object") && !Array.isArray(input) && ("mode" in input || "template" in input)) {
     if ("mode" in input) {
+      // SAFETY: the mode discriminant identifies the replacement instruction form.
       const replacement = input as Extract<AgentAdapterInstructions<TRuntimeConfig, Name>, { mode: "replace" }>
       return [replacement.value].flat(2)
     }
+    // SAFETY: the remaining template discriminant identifies composed instructions.
     const composed = input as Extract<AgentAdapterInstructions<TRuntimeConfig, Name>, { template: unknown }>
     return [composed.template, composed.content].flat(2)
   }

--- a/packages/agent/src/agent-instructions.ts
+++ b/packages/agent/src/agent-instructions.ts
@@ -1,5 +1,6 @@
 import type { WorkspaceName } from "@vite-hub/workspace"
 import { fillInstructionSlot } from "./instruction-composition.ts"
+import { hasRuntimeType } from "./internal/runtime-type.ts"
 import type { AgentAdapterInstructions, AgentAdapterMetadataContext, AgentInstructionsContent, AgentRuntimeConfig } from "./types.ts"
 
 async function resolveContent<TRuntimeConfig extends AgentRuntimeConfig, Name extends WorkspaceName>(
@@ -7,7 +8,7 @@ async function resolveContent<TRuntimeConfig extends AgentRuntimeConfig, Name ex
   context: AgentAdapterMetadataContext<TRuntimeConfig, Name>,
 ): Promise<string> {
   const parts = Array.isArray(input) ? input : [input]
-  const resolved = await Promise.all(parts.map(part => typeof part === "function" ? part(context) : part))
+  const resolved = await Promise.all(parts.map(part => hasRuntimeType(part, "function") ? part(context) : part))
   return resolved.flatMap(part => Array.isArray(part) ? part : [part]).map(part => part?.trim()).filter(Boolean).join("\n\n")
 }
 
@@ -16,7 +17,7 @@ export async function resolveAgentInstructions<TRuntimeConfig extends AgentRunti
   input: AgentAdapterInstructions<TRuntimeConfig, Name> | undefined,
   context: AgentAdapterMetadataContext<TRuntimeConfig, Name>,
 ): Promise<string> {
-  if (input && typeof input === "object" && !Array.isArray(input)) {
+  if (input && hasRuntimeType(input, "object") && !Array.isArray(input)) {
     if ("mode" in input) return await resolveContent(input.value, context)
     const template = await resolveContent(input.template, context)
     const content = await resolveContent(input.content, context)
@@ -29,7 +30,7 @@ export async function resolveAgentInstructions<TRuntimeConfig extends AgentRunti
 export function agentInstructionSources<TRuntimeConfig extends AgentRuntimeConfig, Name extends WorkspaceName>(
   input: AgentAdapterInstructions<TRuntimeConfig, Name> | undefined,
 ) {
-  if (input && typeof input === "object" && !Array.isArray(input)) {
+  if (input && hasRuntimeType(input, "object") && !Array.isArray(input)) {
     return ("mode" in input ? [input.value] : [input.template, input.content]).flat(2)
   }
   return [input].flat(2)

--- a/packages/agent/src/agent-instructions.ts
+++ b/packages/agent/src/agent-instructions.ts
@@ -1,0 +1,36 @@
+import type { WorkspaceName } from "@vite-hub/workspace"
+import { fillInstructionSlot } from "./instruction-composition.ts"
+import type { AgentAdapterInstructions, AgentAdapterMetadataContext, AgentInstructionsContent, AgentRuntimeConfig } from "./types.ts"
+
+async function resolveContent<TRuntimeConfig extends AgentRuntimeConfig, Name extends WorkspaceName>(
+  input: AgentInstructionsContent<TRuntimeConfig, Name> | undefined,
+  context: AgentAdapterMetadataContext<TRuntimeConfig, Name>,
+): Promise<string> {
+  const parts = Array.isArray(input) ? input : [input]
+  const resolved = await Promise.all(parts.map(part => typeof part === "function" ? part(context) : part))
+  return resolved.flatMap(part => Array.isArray(part) ? part : [part]).map(part => part?.trim()).filter(Boolean).join("\n\n")
+}
+
+/** Resolve one document before provider-specific instruction composition. */
+export async function resolveAgentInstructions<TRuntimeConfig extends AgentRuntimeConfig, Name extends WorkspaceName>(
+  input: AgentAdapterInstructions<TRuntimeConfig, Name> | undefined,
+  context: AgentAdapterMetadataContext<TRuntimeConfig, Name>,
+): Promise<string> {
+  if (input && typeof input === "object" && !Array.isArray(input)) {
+    if ("mode" in input) return await resolveContent(input.value, context)
+    const template = await resolveContent(input.template, context)
+    const content = await resolveContent(input.content, context)
+    return await fillInstructionSlot(template, content)
+  }
+  return await resolveContent(input, context)
+}
+
+/** Unresolved sources for synchronous inspection and dynamic resolver detection. */
+export function agentInstructionSources<TRuntimeConfig extends AgentRuntimeConfig, Name extends WorkspaceName>(
+  input: AgentAdapterInstructions<TRuntimeConfig, Name> | undefined,
+) {
+  if (input && typeof input === "object" && !Array.isArray(input)) {
+    return ("mode" in input ? [input.value] : [input.template, input.content]).flat(2)
+  }
+  return [input].flat(2)
+}

--- a/packages/agent/src/agent-instructions.ts
+++ b/packages/agent/src/agent-instructions.ts
@@ -17,7 +17,7 @@ export async function resolveAgentInstructions<TRuntimeConfig extends AgentRunti
   input: AgentAdapterInstructions<TRuntimeConfig, Name> | undefined,
   context: AgentAdapterMetadataContext<TRuntimeConfig, Name>,
 ): Promise<string> {
-  if (input && hasRuntimeType(input, "object") && !Array.isArray(input)) {
+  if (input && hasRuntimeType(input, "object") && !Array.isArray(input) && ("mode" in input || "template" in input)) {
     if ("mode" in input) return await resolveContent(input.value, context)
     const template = await resolveContent(input.template, context)
     const content = await resolveContent(input.content, context)
@@ -30,7 +30,7 @@ export async function resolveAgentInstructions<TRuntimeConfig extends AgentRunti
 export function agentInstructionSources<TRuntimeConfig extends AgentRuntimeConfig, Name extends WorkspaceName>(
   input: AgentAdapterInstructions<TRuntimeConfig, Name> | undefined,
 ) {
-  if (input && hasRuntimeType(input, "object") && !Array.isArray(input)) {
+  if (input && hasRuntimeType(input, "object") && !Array.isArray(input) && ("mode" in input || "template" in input)) {
     return ("mode" in input ? [input.value] : [input.template, input.content]).flat(2)
   }
   return [input].flat(2)

--- a/packages/agent/src/agent-instructions.ts
+++ b/packages/agent/src/agent-instructions.ts
@@ -18,9 +18,13 @@ export async function resolveAgentInstructions<TRuntimeConfig extends AgentRunti
   context: AgentAdapterMetadataContext<TRuntimeConfig, Name>,
 ): Promise<string> {
   if (input && hasRuntimeType(input, "object") && !Array.isArray(input) && ("mode" in input || "template" in input)) {
-    if ("mode" in input) return await resolveContent(input.value, context)
-    const template = await resolveContent(input.template, context)
-    const content = await resolveContent(input.content, context)
+    if ("mode" in input) {
+      const replacement = input as Extract<AgentAdapterInstructions<TRuntimeConfig, Name>, { mode: "replace" }>
+      return await resolveContent(replacement.value, context)
+    }
+    const composed = input as Extract<AgentAdapterInstructions<TRuntimeConfig, Name>, { template: unknown }>
+    const template = await resolveContent(composed.template, context)
+    const content = await resolveContent(composed.content, context)
     return await fillInstructionSlot(template, content)
   }
   return await resolveContent(input, context)
@@ -31,7 +35,12 @@ export function agentInstructionSources<TRuntimeConfig extends AgentRuntimeConfi
   input: AgentAdapterInstructions<TRuntimeConfig, Name> | undefined,
 ) {
   if (input && hasRuntimeType(input, "object") && !Array.isArray(input) && ("mode" in input || "template" in input)) {
-    return ("mode" in input ? [input.value] : [input.template, input.content]).flat(2)
+    if ("mode" in input) {
+      const replacement = input as Extract<AgentAdapterInstructions<TRuntimeConfig, Name>, { mode: "replace" }>
+      return [replacement.value].flat(2)
+    }
+    const composed = input as Extract<AgentAdapterInstructions<TRuntimeConfig, Name>, { template: unknown }>
+    return [composed.template, composed.content].flat(2)
   }
   return [input].flat(2)
 }

--- a/packages/agent/src/agent-layers.ts
+++ b/packages/agent/src/agent-layers.ts
@@ -21,6 +21,14 @@ function merge(parent: unknown, child: unknown, path: string): unknown {
   }
   if (path === "driver") {
     if (hasRuntimeType(parent, "string")) parent = { kind: parent }
+    if (record(child) && record(parent) && !("kind" in parent) && !("kind" in child)
+      && "model" in parent && hasRuntimeType(child.model, "object") && !("run" in child)) {
+      return {
+        ...parent,
+        ...child,
+        instructions: merge(parent.instructions, child.instructions, "driver.instructions"),
+      }
+    }
     if (record(child) && ("run" in child || (record(parent) && "run" in parent && "model" in child))) {
       if (record(parent) && ("run" in parent || "model" in parent) && "model" in child && "instructions" in parent && "instructions" in child) {
         return {

--- a/packages/agent/src/agent-layers.ts
+++ b/packages/agent/src/agent-layers.ts
@@ -22,7 +22,7 @@ function merge(parent: unknown, child: unknown, path: string): unknown {
   if (path === "driver") {
     if (hasRuntimeType(parent, "string")) parent = { kind: parent }
     if (record(child) && ("run" in child || (record(parent) && "run" in parent && "model" in child))) {
-      if (record(parent) && "run" in parent && "model" in child && "instructions" in parent && "instructions" in child) {
+      if (record(parent) && ("run" in parent || "model" in parent) && "model" in child && "instructions" in parent && "instructions" in child) {
         return {
           ...parent,
           ...child,

--- a/packages/agent/src/agent-layers.ts
+++ b/packages/agent/src/agent-layers.ts
@@ -14,6 +14,11 @@ const definitionMaps = new Set(["channels", "workspace.sources", "workspace.skil
 
 function merge(parent: unknown, child: unknown, path: string): unknown {
   if (child === undefined) return parent
+  if (path === "driver.instructions") {
+    if (record(child)) return child
+    if (record(parent) && "template" in parent) return { ...parent, content: child }
+    return child
+  }
   if (path === "driver") {
     if (hasRuntimeType(parent, "string")) parent = { kind: parent }
     if (record(child) && ("run" in child || (record(parent) && "run" in parent && "model" in child))) return child

--- a/packages/agent/src/agent-layers.ts
+++ b/packages/agent/src/agent-layers.ts
@@ -21,7 +21,16 @@ function merge(parent: unknown, child: unknown, path: string): unknown {
   }
   if (path === "driver") {
     if (hasRuntimeType(parent, "string")) parent = { kind: parent }
-    if (record(child) && ("run" in child || (record(parent) && "run" in parent && "model" in child))) return child
+    if (record(child) && ("run" in child || (record(parent) && "run" in parent && "model" in child))) {
+      if (record(parent) && "run" in parent && "model" in child && "instructions" in parent && "instructions" in child) {
+        return {
+          ...parent,
+          ...child,
+          instructions: merge(parent.instructions, child.instructions, "driver.instructions"),
+        }
+      }
+      return child
+    }
     if (record(child) && hasRuntimeType(child.model, "object")) return child
   }
   if (path === "workspace" && record(parent) && record(child) && (("name" in parent) !== ("name" in child))) return child

--- a/packages/agent/src/ai-sdk.ts
+++ b/packages/agent/src/ai-sdk.ts
@@ -1,3 +1,4 @@
+import { resolveAgentInstructions } from "./agent-instructions.ts"
 import { asUnknownBoundary, hasRuntimeType } from "./internal/runtime-type.ts"
 import { formatRuntimeDiagnosticError } from "@vite-hub/runtime"
 import { readAgentErrorProperty } from "./agent-error.ts"
@@ -797,12 +798,7 @@ function joinInstructions(...parts: Array<AgentAdapterInstructionsValue | undefi
 }
 
 async function resolveInstructions(options: AiSdkAdapterOptions, context: AgentAdapterMetadataContext) {
-  const parts = Array.isArray(options.instructions) ? options.instructions : [options.instructions]
-  const instructions = await Promise.all(parts.map(part => hasRuntimeType(part, "function")
-    ? part(context)
-    : part))
-
-  return joinInstructions(...instructions)
+  return await resolveAgentInstructions(options.instructions, context)
 }
 
 async function composeInstructions(

--- a/packages/agent/src/index.ts
+++ b/packages/agent/src/index.ts
@@ -264,6 +264,7 @@ export type {
   AgentAdapterInstructions,
   AgentAdapterInstructionsPart,
   AgentAdapterInstructionsValue,
+  AgentInstructionsContent,
   AgentAdapterMetadataContext,
   AgentAdapterResult,
   AgentAdapterRunContext,

--- a/packages/agent/src/instruction-composition.ts
+++ b/packages/agent/src/instruction-composition.ts
@@ -94,6 +94,21 @@ export async function composeInstructionDocument(content: string, options: Compo
   }
 }
 
+/** Insert trusted instruction Markdown without consuming other runtime bindings. */
+export async function fillInstructionSlot(template: string, content: string): Promise<string> {
+  const pattern = /\{\{\{\s*instructions\s*\}\}\}/g
+  const prefix = `VITEHUBINSTRUCTIONSLOT${crypto.randomUUID().replaceAll("-", "")}`
+  let index = 0
+  const masked = template.replace(pattern, () => `${prefix}${index++}END`)
+  const { tree } = await parseInstructionTemplate(masked)
+  const code = instructionTokensInCode(tree.nodes, prefix)
+  if (index - code.size !== 1) {
+    throw new TypeError("[vitehub] Instruction templates require exactly one {{{ instructions }}} slot outside code.")
+  }
+  index = 0
+  return template.replace(pattern, match => code.has(index++) ? match : content)
+}
+
 async function validateInstructionMarkdownBindings(content: string): Promise<void> {
   if (!content.includes("{{{")) return
   const { tags, tree } = await parseInstructionTemplate(content)

--- a/packages/agent/src/provider-agent.ts
+++ b/packages/agent/src/provider-agent.ts
@@ -1,3 +1,4 @@
+import { resolveAgentInstructions } from "./agent-instructions.ts"
 import { getMessageText } from "./messages.ts"
 import { hasRuntimeType, isRuntimeRecord } from "./internal/runtime-type.ts"
 import { spawn } from "node:child_process"
@@ -1666,10 +1667,9 @@ async function resolveInstructions<
   CALL_OPTIONS,
 >(options: ProviderAgentAdapterOptions<TRuntimeConfig, CALL_OPTIONS>, context: AgentAdapterRunContext<CALL_OPTIONS, TRuntimeConfig>): Promise<string | undefined> {
   const metadataContext = providerMetadataContext(context)
-  const parts = Array.isArray(options.instructions) ? options.instructions : [options.instructions]
-  const configured = await Promise.all(parts.map(part => hasRuntimeType(part, "function") ? part(metadataContext) : part))
+  const configured = await resolveAgentInstructions(options.instructions, metadataContext)
   const content = [
-    ...configured.flatMap(value => Array.isArray(value) ? value : [value]),
+    configured,
     context.instructions,
     resolveMessageChannelInstructions(context.context, context),
     agentOutputInstructions(context.output),
@@ -2800,10 +2800,9 @@ export function createProviderAgentAdapter<
   return {
     generate: context => generateProvider(runProvider(options, resumeCursors, sessionLocks, context), context),
     async metadata(context) {
-      const parts = Array.isArray(options.instructions) ? options.instructions : [options.instructions]
-      const instructions = await Promise.all(parts.map(part => hasRuntimeType(part, "function") ? part(context) : part))
+      const instructions = await resolveAgentInstructions(options.instructions, context)
       return {
-        instructions: instructions.flatMap(value => Array.isArray(value) ? value : value ? [value] : []),
+        instructions: instructions ? [instructions] : [],
       }
     },
     name: options.provider,

--- a/packages/agent/src/types.ts
+++ b/packages/agent/src/types.ts
@@ -1193,6 +1193,23 @@ export type AgentAdapterInstructions<
   TRuntimeConfig extends AgentRuntimeConfig = AgentRuntimeConfig,
   Name extends WorkspaceName = WorkspaceName,
 > =
+  | AgentInstructionsContent<TRuntimeConfig, Name>
+  | {
+    /** Markdown with exactly one {{{ instructions }}} slot outside code. */
+    template: AgentInstructionsContent<TRuntimeConfig, Name>
+    /** Default slot content. Extending instructions replaces this content. */
+    content?: AgentInstructionsContent<TRuntimeConfig, Name>
+  }
+  | {
+    /** Discard an inherited template and use this document. */
+    mode: "replace"
+    value: AgentInstructionsContent<TRuntimeConfig, Name>
+  }
+
+export type AgentInstructionsContent<
+  TRuntimeConfig extends AgentRuntimeConfig = AgentRuntimeConfig,
+  Name extends WorkspaceName = WorkspaceName,
+> =
   | AgentAdapterInstructionsPart<TRuntimeConfig, Name>
   | Array<AgentAdapterInstructionsPart<TRuntimeConfig, Name>>
 

--- a/packages/agent/src/workspace-agent.ts
+++ b/packages/agent/src/workspace-agent.ts
@@ -1327,7 +1327,7 @@ function fillSynchronousInstructionSlot(template: string, content: string): stri
     if (fence) return line
     const indented = /^(?:    |\t)/.test(line)
     if (indented && !paragraph) return line
-    paragraph = line.trim().length > 0 && !indented && !/^ {0,3}(?:#{1,6}\s|>|[-+*]\s|\d+[.)]\s)/.test(line)
+    paragraph = line.trim().length > 0 && !indented && (!/^ {0,3}(?:#{1,6}\s|>)/.test(line) || /^ {0,3}(?:[-+*]\s|\d+[.)]\s)/.test(line))
     if (inlineFence) {
       const run = inlineFence
       const end = findInlineCodeClose(line, run)

--- a/packages/agent/src/workspace-agent.ts
+++ b/packages/agent/src/workspace-agent.ts
@@ -1289,18 +1289,35 @@ function workspaceMetadataInstructions<
   })
   const composed = instructionObject
     && typeof instructionObject.template === "string"
-    && typeof instructionObject.content === "string"
-    ? fillSynchronousInstructionSlot(instructionObject.template, instructionObject.content)
+    ? fillSynchronousInstructionSlot(
+      instructionObject.template,
+      Array.isArray(instructionObject.content)
+        ? instructionObject.content.filter((part): part is string => typeof part === "string").join("\n\n")
+        : typeof instructionObject.content === "string" ? instructionObject.content : "",
+    )
     : undefined
   const content = [...(defaultInstructions ? [defaultInstructions] : []), ...(composed ? [composed] : instructions)].join("\n\n").trim()
   return content ? [content] : []
 }
 
 function fillSynchronousInstructionSlot(template: string, content: string): string {
-  let inFence = false
+  let fence: string | undefined
   return template.split("\n").map((line) => {
-    if (/^\s*```/.test(line)) { inFence = !inFence; return line }
-    return !inFence ? line.replace(/\{\{\{\s*instructions\s*\}\}\}/g, content) : line
+    const marker = line.match(/^\s*(`{3,}|~{3,})/)
+    if (marker) { fence = fence ? (line.trimStart().startsWith(fence) ? undefined : fence) : marker[1]; return line }
+    if (fence) return line
+    let result = ""
+    let index = 0
+    for (const match of line.matchAll(/`+/g)) {
+      const start = match.index ?? 0
+      result += line.slice(index, start).replace(/\{\{\{\s*instructions\s*\}\}\}/g, content)
+      const ticks = match[0]
+      const end = line.indexOf(ticks, start + ticks.length)
+      if (end < 0) { result += line.slice(start); index = line.length; break }
+      result += line.slice(start, end + ticks.length)
+      index = end + ticks.length
+    }
+    return result + line.slice(index).replace(/\{\{\{\s*instructions\s*\}\}\}/g, content)
   }).join("\n").trim()
 }
 

--- a/packages/agent/src/workspace-agent.ts
+++ b/packages/agent/src/workspace-agent.ts
@@ -1301,7 +1301,7 @@ function workspaceMetadataInstructions<
     && templateParts.every((part): part is string => hasRuntimeType(part, "string"))
     ? fillSynchronousInstructionSlot(templateParts.join("\n\n"), slotContent)
     : undefined
-  const content = [...(defaultInstructions ? [defaultInstructions] : []), ...(composed ? [composed] : instructions)].join("\n\n").trim()
+  const content = [...(defaultInstructions ? [defaultInstructions] : []), ...(composed !== undefined ? [composed] : instructions)].join("\n\n").trim()
   return content ? [content] : []
 }
 

--- a/packages/agent/src/workspace-agent.ts
+++ b/packages/agent/src/workspace-agent.ts
@@ -1274,6 +1274,9 @@ function workspaceMetadataInstructions<
   const defaultInstructions = shouldUseColocatedAgentInstructions(options)
     ? readColocatedAgentInstructionsRaw(options)
     : undefined
+  const instructionObject = configuredInstructions && hasRuntimeType(configuredInstructions, "object") && !Array.isArray(configuredInstructions) && !("mode" in configuredInstructions)
+    ? configuredInstructions
+    : undefined
   const parts = agentInstructionSources(configuredInstructions)
   const instructions = parts.flatMap((part) => {
     if (hasRuntimeType(part, "string") && part.trim().length > 0) return [part]
@@ -1285,8 +1288,20 @@ function workspaceMetadataInstructions<
     return []
   })
   if (defaultInstructions) instructions.unshift(defaultInstructions)
-  const content = instructions.join("\n\n").trim()
+  const content = instructionObject
+    && typeof instructionObject.template === "string"
+    && typeof instructionObject.content === "string"
+    ? fillSynchronousInstructionSlot(instructionObject.template, instructionObject.content)
+    : instructions.join("\n\n").trim()
   return content ? [content] : []
+}
+
+function fillSynchronousInstructionSlot(template: string, content: string): string {
+  let inFence = false
+  return template.split("\n").map((line) => {
+    if (/^\s*```/.test(line)) { inFence = !inFence; return line }
+    return !inFence ? line.replace(/\{\{\{\s*instructions\s*\}\}\}/g, content) : line
+  }).join("\n").trim()
 }
 
 async function staticWorkspaceMetadataInstructions<

--- a/packages/agent/src/workspace-agent.ts
+++ b/packages/agent/src/workspace-agent.ts
@@ -1295,10 +1295,11 @@ function workspaceMetadataInstructions<
     ? (resolveLocalInstructions ? readLocalWorkspaceInstructions(options) : undefined)
       ?? "Dynamic system instructions resolver configured."
     : slotParts.filter((part): part is string => hasRuntimeType(part, "string")).join("\n\n")
+  const templateParts = Array.isArray(instructionObject?.template) ? instructionObject.template : [instructionObject?.template]
   const composed = instructionObject
     && !slotIsDynamic
-    && hasRuntimeType(instructionObject.template, "string")
-    ? fillSynchronousInstructionSlot(instructionObject.template, slotContent)
+    && templateParts.every((part): part is string => hasRuntimeType(part, "string"))
+    ? fillSynchronousInstructionSlot(templateParts.join("\n\n"), slotContent)
     : undefined
   const content = [...(defaultInstructions ? [defaultInstructions] : []), ...(composed ? [composed] : instructions)].join("\n\n").trim()
   return content ? [content] : []

--- a/packages/agent/src/workspace-agent.ts
+++ b/packages/agent/src/workspace-agent.ts
@@ -1318,7 +1318,7 @@ function fillSynchronousInstructionSlot(template: string, content: string): stri
   return template.split("\n").map((line) => {
     // Fenced blocks may occur inside block quotes; include the container
     // prefix when classifying delimiters so static inspection matches Markdown.
-    const marker = line.match(/^( {0,3}(?:> ?)*)(`{3,}|~{3,})(.*)$/)
+    const marker = line.match(/^( {0,3}(?:(?:> ?)*|(?:[-+*]|\d+[.)])[ \t]+))(`{3,}|~{3,})(.*)$/)
     if (marker) {
       const delimiter = marker[2]
       const trailing = marker[3]

--- a/packages/agent/src/workspace-agent.ts
+++ b/packages/agent/src/workspace-agent.ts
@@ -1311,11 +1311,14 @@ function fillSynchronousInstructionSlot(template: string, content: string): stri
     if (fence) return line
     let result = ""
     let index = 0
-    for (const match of line.matchAll(/`+/g)) {
-      const start = match.index ?? 0
+    while (index < line.length) {
+      const start = line.indexOf("`", index)
+      if (start < 0) break
       result += line.slice(index, start).replace(/\{\{\{\s*instructions\s*\}\}\}/g, content)
-      const ticks = match[0]
-      const end = line.indexOf(ticks, start + ticks.length)
+      let tickEnd = start
+      while (line[tickEnd] === "`") tickEnd++
+      const ticks = line.slice(start, tickEnd)
+      const end = line.indexOf(ticks, tickEnd)
       if (end < 0) { result += line.slice(start); index = line.length; break }
       result += line.slice(start, end + ticks.length)
       index = end + ticks.length

--- a/packages/agent/src/workspace-agent.ts
+++ b/packages/agent/src/workspace-agent.ts
@@ -1294,10 +1294,10 @@ function workspaceMetadataInstructions<
   const slotContent = slotIsDynamic
     ? (resolveLocalInstructions ? readLocalWorkspaceInstructions(options) : undefined)
       ?? "Dynamic system instructions resolver configured."
-    : slotParts.filter((part): part is string => typeof part === "string").join("\n\n")
+    : slotParts.filter((part): part is string => hasRuntimeType(part, "string")).join("\n\n")
   const composed = instructionObject
     && !slotIsDynamic
-    && typeof instructionObject.template === "string"
+    && hasRuntimeType(instructionObject.template, "string")
     ? fillSynchronousInstructionSlot(instructionObject.template, slotContent)
     : undefined
   const content = [...(defaultInstructions ? [defaultInstructions] : []), ...(composed ? [composed] : instructions)].join("\n\n").trim()

--- a/packages/agent/src/workspace-agent.ts
+++ b/packages/agent/src/workspace-agent.ts
@@ -1294,7 +1294,7 @@ function workspaceMetadataInstructions<
   const slotContent = slotIsDynamic
     ? (resolveLocalInstructions ? readLocalWorkspaceInstructions(options) : undefined)
       ?? "Dynamic system instructions resolver configured."
-    : slotParts.filter((part): part is string => hasRuntimeType(part, "string")).join("\n\n")
+    : slotParts.filter((part): part is string => hasRuntimeType(part, "string") && part.trim().length > 0).map(part => part.trim()).join("\n\n")
   const templateParts = Array.isArray(instructionObject?.template) ? instructionObject.template : [instructionObject?.template]
   const composed = instructionObject
     && !slotIsDynamic
@@ -1327,7 +1327,7 @@ function fillSynchronousInstructionSlot(template: string, content: string): stri
     if (fence) return line
     const indented = /^(?:    |\t)/.test(line)
     if (indented && !paragraph) return line
-    paragraph = line.trim().length > 0 && !indented
+    paragraph = line.trim().length > 0 && !indented && !/^ {0,3}(?:#{1,6}\s|>|[-+*]\s|\d+[.)]\s)/.test(line)
     if (inlineFence) {
       const run = inlineFence
       const end = findInlineCodeClose(line, run)
@@ -1348,7 +1348,9 @@ function fillSynchronousInstructionSlot(template: string, content: string): stri
         continue
       }
       // A backslash-escaped backtick is ordinary text, not an inline-code delimiter.
-      if (index > 0 && line[index - 1] === "\\") {
+      let backslashes = 0
+      for (let cursor = index - 1; cursor >= 0 && line[cursor] === "\\"; cursor--) backslashes++
+      if (backslashes % 2 === 1) {
         out += "`"
         index++
         continue

--- a/packages/agent/src/workspace-agent.ts
+++ b/packages/agent/src/workspace-agent.ts
@@ -1359,7 +1359,12 @@ function fillSynchronousInstructionSlot(template: string, content: string): stri
       while (line[index] === "`") index++
       const run = line.slice(start, index)
       const end = findInlineCodeClose(line, run, index)
-      if (end < 0) { out += line.slice(start); inlineFence = run; break }
+      if (end < 0) {
+        // An unmatched backtick run is literal text in CommonMark; do not
+        // carry code-span state into subsequent lines.
+        out += line.slice(start).replace(/\{\{\{\s*instructions\s*\}\}\}/g, content)
+        break
+      }
       out += line.slice(start, end + run.length)
       index = end + run.length
     }

--- a/packages/agent/src/workspace-agent.ts
+++ b/packages/agent/src/workspace-agent.ts
@@ -1274,7 +1274,7 @@ function workspaceMetadataInstructions<
   const defaultInstructions = shouldUseColocatedAgentInstructions(options)
     ? readColocatedAgentInstructionsRaw(options)
     : undefined
-  const instructionObject = configuredInstructions && hasRuntimeType(configuredInstructions, "object") && !Array.isArray(configuredInstructions) && !("mode" in configuredInstructions)
+  const instructionObject = configuredInstructions && hasRuntimeType(configuredInstructions, "object") && !Array.isArray(configuredInstructions) && !("mode" in configuredInstructions) && "template" in configuredInstructions
     ? configuredInstructions
     : undefined
   const parts = agentInstructionSources(configuredInstructions)

--- a/packages/agent/src/workspace-agent.ts
+++ b/packages/agent/src/workspace-agent.ts
@@ -1326,7 +1326,10 @@ function fillSynchronousInstructionSlot(template: string, content: string): stri
     }
     if (fence) return line
     const indented = /^(?:    |\t)/.test(line)
-    if (indented && !paragraph) return line
+    // A deeply indented continuation under a list item is an indented code
+    // block; only the standard four-space paragraph continuation is prose.
+    const indentation = line.match(/^ */)?.[0].length ?? 0
+    if (indented && (!paragraph || indentation > 4)) return line
     paragraph = line.trim().length > 0 && !indented && (!/^ {0,3}(?:#{1,6}\s|>)/.test(line) || /^ {0,3}(?:[-+*]\s|\d+[.)]\s)/.test(line))
     if (inlineFence) {
       const run = inlineFence

--- a/packages/agent/src/workspace-agent.ts
+++ b/packages/agent/src/workspace-agent.ts
@@ -1347,6 +1347,12 @@ function fillSynchronousInstructionSlot(template: string, content: string): stri
         index = end
         continue
       }
+      // A backslash-escaped backtick is ordinary text, not an inline-code delimiter.
+      if (index > 0 && line[index - 1] === "\\") {
+        out += "`"
+        index++
+        continue
+      }
       const start = index
       while (line[index] === "`") index++
       const run = line.slice(start, index)

--- a/packages/agent/src/workspace-agent.ts
+++ b/packages/agent/src/workspace-agent.ts
@@ -1296,6 +1296,7 @@ function workspaceMetadataInstructions<
       ?? "Dynamic system instructions resolver configured."
     : slotParts.filter((part): part is string => typeof part === "string").join("\n\n")
   const composed = instructionObject
+    && !slotIsDynamic
     && typeof instructionObject.template === "string"
     ? fillSynchronousInstructionSlot(instructionObject.template, slotContent)
     : undefined
@@ -1308,22 +1309,21 @@ function fillSynchronousInstructionSlot(template: string, content: string): stri
   return template.split("\n").map((line) => {
     const marker = line.match(/^\s*(`{3,}|~{3,})/)
     if (marker) { fence = fence ? (line.trimStart().startsWith(fence) ? undefined : fence) : marker[1]; return line }
-    if (fence) return line
-    let result = ""
+    if (fence || /^(?:    |\t)/.test(line)) return line
+    let out = ""
     let index = 0
     while (index < line.length) {
-      const start = line.indexOf("`", index)
-      if (start < 0) break
-      result += line.slice(index, start).replace(/\{\{\{\s*instructions\s*\}\}\}/g, content)
-      let tickEnd = start
-      while (line[tickEnd] === "`") tickEnd++
-      const ticks = line.slice(start, tickEnd)
-      const end = line.indexOf(ticks, tickEnd)
-      if (end < 0) { result += line.slice(start); index = line.length; break }
-      result += line.slice(start, end + ticks.length)
-      index = end + ticks.length
+      const tick = line[index]
+      if (tick !== "`") { out += line[index++]; continue }
+      const start = index
+      while (line[index] === "`") index++
+      const run = line.slice(start, index)
+      const end = line.indexOf(run, index)
+      if (end < 0) { out += line.slice(start); break }
+      out += line.slice(start, end + run.length)
+      index = end + run.length
     }
-    return result + line.slice(index).replace(/\{\{\{\s*instructions\s*\}\}\}/g, content)
+    return out.replace(/\{\{\{\s*instructions\s*\}\}\}/g, content)
   }).join("\n").trim()
 }
 

--- a/packages/agent/src/workspace-agent.ts
+++ b/packages/agent/src/workspace-agent.ts
@@ -1305,6 +1305,10 @@ function workspaceMetadataInstructions<
   return content ? [content] : []
 }
 
+function replaceInstructionSlots(value: string, content: string): string {
+  return value.replace(/\{\{\{\s*instructions\s*\}\}\}/g, content)
+}
+
 function fillSynchronousInstructionSlot(template: string, content: string): string {
   let fence: string | undefined
   let inlineFence: string | undefined
@@ -1330,7 +1334,7 @@ function fillSynchronousInstructionSlot(template: string, content: string): stri
       if (end < 0) return line
       inlineFence = undefined
       const closeEnd = end + run.length
-      return line.slice(0, closeEnd) + line.slice(closeEnd).replace(/\{\{\{\s*instructions\s*\}\}\}/g, content)
+      return line.slice(0, closeEnd) + replaceInstructionSlots(line.slice(closeEnd), content)
     }
     let out = ""
     let index = 0

--- a/packages/agent/src/workspace-agent.ts
+++ b/packages/agent/src/workspace-agent.ts
@@ -1330,7 +1330,7 @@ function fillSynchronousInstructionSlot(template: string, content: string): stri
     paragraph = line.trim().length > 0 && !indented
     if (inlineFence) {
       const run = inlineFence
-      const end = line.indexOf(run)
+      const end = findInlineCodeClose(line, run)
       if (end < 0) return line
       inlineFence = undefined
       const closeEnd = end + run.length
@@ -1350,13 +1350,27 @@ function fillSynchronousInstructionSlot(template: string, content: string): stri
       const start = index
       while (line[index] === "`") index++
       const run = line.slice(start, index)
-      const end = line.indexOf(run, index)
+      const end = findInlineCodeClose(line, run, index)
       if (end < 0) { out += line.slice(start); inlineFence = run; break }
       out += line.slice(start, end + run.length)
       index = end + run.length
     }
     return out
   }).join("\n")
+}
+
+/** Find a backtick closing run with exactly the same length. */
+function findInlineCodeClose(line: string, run: string, from = 0): number {
+  let index = from
+  while (index < line.length) {
+    const found = line.indexOf(run, index)
+    if (found < 0) return -1
+    const before = found > 0 ? line[found - 1] : ""
+    const after = line[found + run.length] ?? ""
+    if (before !== "`" && after !== "`") return found
+    index = found + 1
+  }
+  return -1
 }
 
 async function staticWorkspaceMetadataInstructions<

--- a/packages/agent/src/workspace-agent.ts
+++ b/packages/agent/src/workspace-agent.ts
@@ -1314,7 +1314,9 @@ function fillSynchronousInstructionSlot(template: string, content: string): stri
   let inlineFence: string | undefined
   let paragraph = false
   return template.split("\n").map((line) => {
-    const marker = line.match(/^( {0,3})(`{3,}|~{3,})(.*)$/)
+    // Fenced blocks may occur inside block quotes; include the container
+    // prefix when classifying delimiters so static inspection matches Markdown.
+    const marker = line.match(/^( {0,3}(?:> ?)*)(`{3,}|~{3,})(.*)$/)
     if (marker) {
       const delimiter = marker[2]
       const trailing = marker[3]

--- a/packages/agent/src/workspace-agent.ts
+++ b/packages/agent/src/workspace-agent.ts
@@ -1318,7 +1318,7 @@ function fillSynchronousInstructionSlot(template: string, content: string): stri
   return template.split("\n").map((line) => {
     // Fenced blocks may occur inside block quotes; include the container
     // prefix when classifying delimiters so static inspection matches Markdown.
-    const marker = line.match(/^( {0,3}(?:(?:> ?)*|(?:[-+*]|\d+[.)])[ \t]+))(`{3,}|~{3,})(.*)$/)
+    const marker = line.match(/^( {0,3}(?:> ?)*(?:(?:[-+*]|\d+[.)])[ \t]+)?)(`{3,}|~{3,})(.*)$/)
     if (marker) {
       const delimiter = marker[2]
       const trailing = marker[3]

--- a/packages/agent/src/workspace-agent.ts
+++ b/packages/agent/src/workspace-agent.ts
@@ -1307,10 +1307,10 @@ function workspaceMetadataInstructions<
 function fillSynchronousInstructionSlot(template: string, content: string): string {
   let fence: string | undefined
   return template.split("\n").map((line) => {
-    const marker = line.match(/^\s*(`{3,}|~{3,})(.*)$/)
+    const marker = line.match(/^( {0,3})(`{3,}|~{3,})(.*)$/)
     if (marker) {
-      const delimiter = marker[1]
-      const trailing = marker[2]
+      const delimiter = marker[2]
+      const trailing = marker[3]
       const isClosing = Boolean(fence && delimiter[0] === fence[0] && delimiter.length >= fence.length && /^\s*$/.test(trailing))
       if (fence) { if (isClosing) fence = undefined; return line }
       if (!/^\s*$/.test(trailing)) { fence = delimiter; return line }
@@ -1338,7 +1338,7 @@ function fillSynchronousInstructionSlot(template: string, content: string): stri
       index = end + run.length
     }
     return out
-  }).join("\n").trim()
+  }).join("\n")
 }
 
 async function staticWorkspaceMetadataInstructions<

--- a/packages/agent/src/workspace-agent.ts
+++ b/packages/agent/src/workspace-agent.ts
@@ -1307,14 +1307,28 @@ function workspaceMetadataInstructions<
 function fillSynchronousInstructionSlot(template: string, content: string): string {
   let fence: string | undefined
   return template.split("\n").map((line) => {
-    const marker = line.match(/^\s*(`{3,}|~{3,})/)
-    if (marker) { fence = fence ? (line.trimStart().startsWith(fence) ? undefined : fence) : marker[1]; return line }
+    const marker = line.match(/^\s*(`{3,}|~{3,})(.*)$/)
+    if (marker) {
+      const delimiter = marker[1]
+      const trailing = marker[2]
+      const isClosing = Boolean(fence && delimiter[0] === fence[0] && delimiter.length >= fence.length && /^\s*$/.test(trailing))
+      if (fence) { if (isClosing) fence = undefined; return line }
+      if (!/^\s*$/.test(trailing)) { fence = delimiter; return line }
+      fence = delimiter
+      return line
+    }
     if (fence || /^(?:    |\t)/.test(line)) return line
     let out = ""
     let index = 0
     while (index < line.length) {
       const tick = line[index]
-      if (tick !== "`") { out += line[index++]; continue }
+      if (tick !== "`") {
+        const next = line.indexOf("`", index)
+        const end = next < 0 ? line.length : next
+        out += line.slice(index, end).replace(/\{\{\{\s*instructions\s*\}\}\}/g, content)
+        index = end
+        continue
+      }
       const start = index
       while (line[index] === "`") index++
       const run = line.slice(start, index)
@@ -1323,7 +1337,7 @@ function fillSynchronousInstructionSlot(template: string, content: string): stri
       out += line.slice(start, end + run.length)
       index = end + run.length
     }
-    return out.replace(/\{\{\{\s*instructions\s*\}\}\}/g, content)
+    return out
   }).join("\n").trim()
 }
 

--- a/packages/agent/src/workspace-agent.ts
+++ b/packages/agent/src/workspace-agent.ts
@@ -1314,6 +1314,7 @@ function fillSynchronousInstructionSlot(template: string, content: string): stri
   let inlineFence: string | undefined
   let paragraph = false
   let listContinuationIndent = 4
+  let listActive = false
   return template.split("\n").map((line) => {
     // Fenced blocks may occur inside block quotes; include the container
     // prefix when classifying delimiters so static inspection matches Markdown.
@@ -1330,9 +1331,14 @@ function fillSynchronousInstructionSlot(template: string, content: string): stri
     if (fence) return line
     const indented = /^(?:    |\t)/.test(line)
     const indentation = line.match(/^ */)?.[0].length ?? 0
-    if (indented && (!paragraph || indentation > listContinuationIndent)) return line
+    if (indented && (!paragraph || (listActive && indentation > listContinuationIndent))) return line
     const list = line.match(/^( {0,3})(?:[-+*]|\d+[.)])([ \t]+)/)
-    if (list) listContinuationIndent = (list[1]?.length ?? 0) + (list[0]?.length ?? 0) + 3
+    if (list) {
+      listContinuationIndent = (list[1]?.length ?? 0) + (list[0]?.length ?? 0) + 3
+      listActive = true
+    } else if (!indented && line.trim().length > 0) {
+      listActive = false
+    }
     paragraph = line.trim().length > 0 && !indented && (!/^ {0,3}(?:#{1,6}\s|>)/.test(line) || Boolean(list))
     if (inlineFence) {
       const run = inlineFence

--- a/packages/agent/src/workspace-agent.ts
+++ b/packages/agent/src/workspace-agent.ts
@@ -1307,6 +1307,8 @@ function workspaceMetadataInstructions<
 
 function fillSynchronousInstructionSlot(template: string, content: string): string {
   let fence: string | undefined
+  let inlineFence: string | undefined
+  let paragraph = false
   return template.split("\n").map((line) => {
     const marker = line.match(/^( {0,3})(`{3,}|~{3,})(.*)$/)
     if (marker) {
@@ -1318,7 +1320,18 @@ function fillSynchronousInstructionSlot(template: string, content: string): stri
       fence = delimiter
       return line
     }
-    if (fence || /^(?:    |\t)/.test(line)) return line
+    if (fence) return line
+    const indented = /^(?:    |\t)/.test(line)
+    if (indented && !paragraph) return line
+    paragraph = line.trim().length > 0 && !indented
+    if (inlineFence) {
+      const run = inlineFence
+      const end = line.indexOf(run)
+      if (end < 0) return line
+      inlineFence = undefined
+      const closeEnd = end + run.length
+      return line.slice(0, closeEnd) + line.slice(closeEnd).replace(/\{\{\{\s*instructions\s*\}\}\}/g, content)
+    }
     let out = ""
     let index = 0
     while (index < line.length) {
@@ -1334,7 +1347,7 @@ function fillSynchronousInstructionSlot(template: string, content: string): stri
       while (line[index] === "`") index++
       const run = line.slice(start, index)
       const end = line.indexOf(run, index)
-      if (end < 0) { out += line.slice(start); break }
+      if (end < 0) { out += line.slice(start); inlineFence = run; break }
       out += line.slice(start, end + run.length)
       index = end + run.length
     }

--- a/packages/agent/src/workspace-agent.ts
+++ b/packages/agent/src/workspace-agent.ts
@@ -1287,14 +1287,17 @@ function workspaceMetadataInstructions<
     }
     return []
   })
+  const slotParts = Array.isArray(instructionObject?.content)
+    ? instructionObject.content
+    : [instructionObject?.content]
+  const slotIsDynamic = slotParts.some(part => hasRuntimeType(part, "function"))
+  const slotContent = slotIsDynamic
+    ? (resolveLocalInstructions ? readLocalWorkspaceInstructions(options) : undefined)
+      ?? "Dynamic system instructions resolver configured."
+    : slotParts.filter((part): part is string => typeof part === "string").join("\n\n")
   const composed = instructionObject
     && typeof instructionObject.template === "string"
-    ? fillSynchronousInstructionSlot(
-      instructionObject.template,
-      Array.isArray(instructionObject.content)
-        ? instructionObject.content.filter((part): part is string => typeof part === "string").join("\n\n")
-        : typeof instructionObject.content === "string" ? instructionObject.content : "",
-    )
+    ? fillSynchronousInstructionSlot(instructionObject.template, slotContent)
     : undefined
   const content = [...(defaultInstructions ? [defaultInstructions] : []), ...(composed ? [composed] : instructions)].join("\n\n").trim()
   return content ? [content] : []

--- a/packages/agent/src/workspace-agent.ts
+++ b/packages/agent/src/workspace-agent.ts
@@ -1287,12 +1287,12 @@ function workspaceMetadataInstructions<
     }
     return []
   })
-  if (defaultInstructions) instructions.unshift(defaultInstructions)
-  const content = instructionObject
+  const composed = instructionObject
     && typeof instructionObject.template === "string"
     && typeof instructionObject.content === "string"
     ? fillSynchronousInstructionSlot(instructionObject.template, instructionObject.content)
-    : instructions.join("\n\n").trim()
+    : undefined
+  const content = [...(defaultInstructions ? [defaultInstructions] : []), ...(composed ? [composed] : instructions)].join("\n\n").trim()
   return content ? [content] : []
 }
 

--- a/packages/agent/src/workspace-agent.ts
+++ b/packages/agent/src/workspace-agent.ts
@@ -1313,6 +1313,7 @@ function fillSynchronousInstructionSlot(template: string, content: string): stri
   let fence: string | undefined
   let inlineFence: string | undefined
   let paragraph = false
+  let listContinuationIndent = 4
   return template.split("\n").map((line) => {
     // Fenced blocks may occur inside block quotes; include the container
     // prefix when classifying delimiters so static inspection matches Markdown.
@@ -1328,11 +1329,11 @@ function fillSynchronousInstructionSlot(template: string, content: string): stri
     }
     if (fence) return line
     const indented = /^(?:    |\t)/.test(line)
-    // A deeply indented continuation under a list item is an indented code
-    // block; only the standard four-space paragraph continuation is prose.
     const indentation = line.match(/^ */)?.[0].length ?? 0
-    if (indented && (!paragraph || indentation > 4)) return line
-    paragraph = line.trim().length > 0 && !indented && (!/^ {0,3}(?:#{1,6}\s|>)/.test(line) || /^ {0,3}(?:[-+*]\s|\d+[.)]\s)/.test(line))
+    if (indented && (!paragraph || indentation > listContinuationIndent)) return line
+    const list = line.match(/^( {0,3})(?:[-+*]|\d+[.)])([ \t]+)/)
+    if (list) listContinuationIndent = (list[1]?.length ?? 0) + (list[0]?.length ?? 0) + 3
+    paragraph = line.trim().length > 0 && !indented && (!/^ {0,3}(?:#{1,6}\s|>)/.test(line) || Boolean(list))
     if (inlineFence) {
       const run = inlineFence
       const end = findInlineCodeClose(line, run)

--- a/packages/agent/src/workspace-agent.ts
+++ b/packages/agent/src/workspace-agent.ts
@@ -1,3 +1,4 @@
+import { agentInstructionSources, resolveAgentInstructions } from "./agent-instructions.ts"
 import { asUnknownBoundary, hasRuntimeType, isRuntimeRecord } from "./internal/runtime-type.ts"
 import { listMaterializedWorkspaceEntries, listMaterializedWorkspaceSourceEntries, normalizeWorkspaceSourcesMetadata, readWorkspaceSourceMaterializationStatus, workspaceSourceGrantPaths, type WorkspaceSourceMetadata } from "@vite-hub/workspace/source-metadata"
 import {
@@ -1273,7 +1274,7 @@ function workspaceMetadataInstructions<
   const defaultInstructions = shouldUseColocatedAgentInstructions(options)
     ? readColocatedAgentInstructionsRaw(options)
     : undefined
-  const parts = Array.isArray(configuredInstructions) ? configuredInstructions : [configuredInstructions]
+  const parts = agentInstructionSources(configuredInstructions)
   const instructions = parts.flatMap((part) => {
     if (hasRuntimeType(part, "string") && part.trim().length > 0) return [part]
     if (hasRuntimeType(part, "function")) {
@@ -1299,7 +1300,7 @@ async function staticWorkspaceMetadataInstructions<
   const instructions = workspaceMetadataInstructions(options, false)
   const coverage = await collectStaticInstructionCoverage(instructions.join("\n\n"))
   const configuredInstructions = modelDriverInstructions(options)
-  const hasDynamicInstructions = (Array.isArray(configuredInstructions) ? configuredInstructions : [configuredInstructions])
+  const hasDynamicInstructions = agentInstructionSources(configuredInstructions)
     .some(instruction => hasRuntimeType(instruction, "function"))
   const visibleSources = new Set(workspaceMetadataFiles(options, context).map(file => file.source).filter(Boolean))
   const visibleDefinition = definition.sources
@@ -1399,15 +1400,10 @@ async function resolveWorkspaceMetadataInstructions<
   const defaultInstructions = shouldUseColocatedAgentInstructions(options)
     ? await resolveWorkspaceAgentDefaultInstructions(options, workspace)
     : undefined
-  const parts = Array.isArray(configuredInstructions) ? configuredInstructions : [configuredInstructions]
-  const instructions = await Promise.all(parts.map(part => hasRuntimeType(part, "function")
-    // SAFETY: Workspace definition normalization establishes the asserted owned Workspace contract.
-    ? part(instructionContext as never)
-    : part))
-  const baseInstructions = instructions
-    .flatMap(part => Array.isArray(part) ? part : [part])
-    .map(part => part?.trim())
-    .filter((part): part is string => Boolean(part))
+  const configured = await resolveAgentInstructions(configuredInstructions,
+    // SAFETY: Instruction inspection supplies the existing metadata context boundary.
+    instructionContext as never)
+  const baseInstructions = configured ? [configured] : []
   if (defaultInstructions) baseInstructions.unshift(defaultInstructions)
   const workspaceBindings = await resolveWorkspaceInstructionBindings(sourceDefinition, workspace)
   const coverage = createInstructionCoverage()

--- a/packages/agent/test/agent-layers.test.ts
+++ b/packages/agent/test/agent-layers.test.ts
@@ -89,3 +89,17 @@ describe("Agent definition layers", () => {
     expect(() => defineAgent({ extends: {} as never })).toThrow("requires an Agent Definition")
   })
 })
+
+
+describe("Agent instruction layers", () => {
+  it("fills an inherited instruction template across generations without mutating its defaults", () => {
+    const base = defineAgent({ workspace: {}, driver: { kind: "codex", instructions: { template: "Before\n{{{ instructions }}}\nAfter", content: "Default" } } })
+    const child = defineAgent({ extends: base, driver: { instructions: "Child" } })
+    const grandchild = defineAgent({ extends: child, driver: { instructions: "Grandchild" } })
+    expect(base.__vitehubWorkspaceAgentOptions.driver).toMatchObject({ instructions: { content: "Default" } })
+    expect(child.__vitehubWorkspaceAgentOptions.driver).toMatchObject({ instructions: { template: "Before\n{{{ instructions }}}\nAfter", content: "Child" } })
+    expect(grandchild.__vitehubWorkspaceAgentOptions.driver).toMatchObject({ instructions: { template: "Before\n{{{ instructions }}}\nAfter", content: "Grandchild" } })
+    const replacement = defineAgent({ extends: child, driver: { instructions: { mode: "replace", value: "Replacement" } } })
+    expect(replacement.__vitehubWorkspaceAgentOptions.driver).toMatchObject({ instructions: { mode: "replace", value: "Replacement" } })
+  })
+})

--- a/packages/agent/test/agent-layers.test.ts
+++ b/packages/agent/test/agent-layers.test.ts
@@ -92,6 +92,14 @@ describe("Agent definition layers", () => {
 
 
 describe("Agent instruction layers", () => {
+  it("preserves model preset templates with object-model overrides", () => {
+    const base = defineAgent({ workspace: {}, driver: { model: {} as never, instructions: { template: "Before\n{{{ instructions }}}\nAfter", content: "Default" } } })
+    const model = {} as never
+    const child = defineAgent({ extends: base, driver: { model, instructions: "Child" } })
+    expect(child.__vitehubWorkspaceAgentOptions.driver).toMatchObject({ model, instructions: { template: "Before\n{{{ instructions }}}\nAfter", content: "Child" } })
+    expect(base.__vitehubWorkspaceAgentOptions.driver).toMatchObject({ instructions: { content: "Default" } })
+  })
+
   it("fills an inherited instruction template across generations without mutating its defaults", () => {
     const base = defineAgent({ workspace: {}, driver: { kind: "codex", instructions: { template: "Before\n{{{ instructions }}}\nAfter", content: "Default" } } })
     const child = defineAgent({ extends: base, driver: { instructions: "Child" } })

--- a/packages/agent/test/instruction-composition.test.ts
+++ b/packages/agent/test/instruction-composition.test.ts
@@ -1,9 +1,11 @@
+import { resolveAgentInstructions } from "../src/agent-instructions.ts"
 import { dirname, resolve } from "node:path"
 
 import { describe, expect, it } from "vitest"
 
 import {
   composeInstructionDocument,
+  fillInstructionSlot,
   createInstructionCoverage,
   resolveInstructionImports,
 } from "../src/instruction-composition.ts"
@@ -563,4 +565,34 @@ describe("instruction composition", () => {
     await expect(composeInstructionDocument("@workspace.policy"))
       .rejects.toThrow("workspace import \"@workspace.policy\" is not defined")
   })
+})
+
+
+describe("instruction template slots", () => {
+  it("fills the designated slot without adding labels or consuming runtime bindings", async () => {
+    const filled = await fillInstructionSlot("Before {{ context.name }}.\n\n{{{ instructions }}}\n\nAfter.", "## Policy\nTake care.")
+    expect(filled).toBe("Before {{ context.name }}.\n\n## Policy\nTake care.\n\nAfter.")
+    expect(await composeInstructionDocument(filled, { context: { name: "Quiver" } })).toBe("Before Quiver.\n\n## Policy\n\nTake care.\n\nAfter.")
+  })
+
+  it("preserves examples in code and does not recursively expand inserted content", async () => {
+    const template = "`{{{ instructions }}}`\n\n```md\n{{{ instructions }}}\n```\n\n{{{ instructions }}}"
+    expect(await fillInstructionSlot(template, "Literal {{{ instructions }}} text")).toBe(template.replace(/\{\{\{ instructions \}\}\}$/, "Literal {{{ instructions }}} text"))
+    expect(await fillInstructionSlot("Before\n{{{ instructions }}}\nAfter", "")).toBe("Before\n\nAfter")
+  })
+
+  it("rejects missing and duplicate composition slots", async () => {
+    await expect(fillInstructionSlot("No slot", "Policy")).rejects.toThrow("exactly one")
+    await expect(fillInstructionSlot("`{{{ instructions }}}`", "Policy")).rejects.toThrow("exactly one")
+    await expect(fillInstructionSlot("{{{ instructions }}}\n{{{ instructions }}}", "Policy")).rejects.toThrow("exactly one")
+  })
+})
+
+
+it("resolves dynamic templates and content consistently for adapter metadata", async () => {
+  expect(await resolveAgentInstructions({
+    template: async () => "Before\n\n{{{ instructions }}}\n\nAfter",
+    content: ["First", async () => ["Second", "Third"]],
+  }, {} as never)).toBe("Before\n\nFirst\n\nSecond\n\nThird\n\nAfter")
+  expect(await resolveAgentInstructions({ mode: "replace", value: async () => "Replacement" }, {} as never)).toBe("Replacement")
 })

--- a/packages/agent/test/workspace.test.ts
+++ b/packages/agent/test/workspace.test.ts
@@ -2715,10 +2715,12 @@ describe("defineAgent workspace option", () => {
     const { createAgentInspectionMetadata, defineAgent } = await import("../src/index.ts")
     const agent = defineAgent({
       driver: {
-        instructions: {
-          template: "Before\n{{{ instructions }}}\nAfter",
-          content: "Default",
-        },
+        model: {
+          instructions: {
+            template: "Before\n{{{ instructions }}}\nAfter",
+            content: "Default",
+          },
+        } as never,
       },
     })
 

--- a/packages/agent/test/workspace.test.ts
+++ b/packages/agent/test/workspace.test.ts
@@ -2714,6 +2714,7 @@ describe("defineAgent workspace option", () => {
   it("composes object-form instructions in static inspection metadata", async () => {
     const { createAgentInspectionMetadata, defineAgent } = await import("../src/index.ts")
     const agent = defineAgent({
+      workspace: {},
       driver: {
         instructions: {
           template: "Before\n{{{ instructions }}}\nAfter",

--- a/packages/agent/test/workspace.test.ts
+++ b/packages/agent/test/workspace.test.ts
@@ -2711,6 +2711,20 @@ describe("defineAgent workspace option", () => {
     ].join("\n")])
   })
 
+  it("composes object-form instructions in static inspection metadata", async () => {
+    const { createAgentInspectionMetadata, defineAgent } = await import("../src/index.ts")
+    const agent = defineAgent({
+      driver: {
+        instructions: {
+          template: "Before\n{{{ instructions }}}\nAfter",
+          content: "Default",
+        },
+      },
+    })
+
+    expect(createAgentInspectionMetadata(agent).instructions).toEqual(["Before\nDefault\nAfter"])
+  })
+
   it("keeps Channel guidance in materialized Agent inspection metadata", async () => {
     const { telegram } = await import("../src/channels.ts")
     const { defineAgent, materializeAgentInspectionSourceMetadata } = await import("../src/index.ts")

--- a/packages/agent/test/workspace.test.ts
+++ b/packages/agent/test/workspace.test.ts
@@ -2715,11 +2715,11 @@ describe("defineAgent workspace option", () => {
     const { createAgentInspectionMetadata, defineAgent } = await import("../src/index.ts")
     const agent = defineAgent({
       driver: {
+        instructions: {
+          template: "Before\n{{{ instructions }}}\nAfter",
+          content: "Default",
+        },
         model: {
-          instructions: {
-            template: "Before\n{{{ instructions }}}\nAfter",
-            content: "Default",
-          },
         } as never,
       },
     })

--- a/packages/agent/test/workspace.test.ts
+++ b/packages/agent/test/workspace.test.ts
@@ -2711,13 +2711,16 @@ describe("defineAgent workspace option", () => {
     ].join("\n")])
   })
 
-  it("composes object-form instructions in static inspection metadata", async () => {
+  it.each([
+    "Before\n{{{ instructions }}}\nAfter",
+    ["Before", "{{{ instructions }}}", "After"],
+  ])("composes object-form instructions in static inspection metadata: %j", async (template) => {
     const { createAgentInspectionMetadata, defineAgent } = await import("../src/index.ts")
     const agent = defineAgent({
       workspace: {},
       driver: {
         instructions: {
-          template: "Before\n{{{ instructions }}}\nAfter",
+          template,
           content: "Default",
         },
         model: {
@@ -2725,7 +2728,7 @@ describe("defineAgent workspace option", () => {
       },
     })
 
-    expect(createAgentInspectionMetadata(agent).instructions).toEqual(["Before\nDefault\nAfter"])
+    expect(createAgentInspectionMetadata(agent).instructions).toEqual([Array.isArray(template) ? "Before\n\nDefault\n\nAfter" : "Before\nDefault\nAfter"])
   })
 
   it("keeps Channel guidance in materialized Agent inspection metadata", async () => {


### PR DESCRIPTION
## What changed

Add structured instruction templates for agent composition. Presets can provide a template containing an instruction slot; child definitions supply slot content without generated labels. Explicit replacement discards the inherited template. The resolver is shared across provider, AI SDK, and workspace metadata paths.

The implementation keeps the existing Markdown template engine and adds coverage for fenced code, inheritance, replacement, and provider resolution.

## Validation

- Agent dependency build and publint
- 39 focused instruction/layer tests
- Root lint (existing warnings only)
- Package typecheck
